### PR TITLE
use identical image in config and deploy

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:3.4.10
+DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:3.4.11

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:3.4.10

--- a/config/init.sh
+++ b/config/init.sh
@@ -2,7 +2,9 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-docker run --rm -it cbioportal/cbioportal:3.4.8 cat /cbioportal-webapp/WEB-INF/classes/portal.properties | \
+VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | cut -d '=' -f 2-)
+
+docker run --rm -it $VERSION cat /cbioportal-webapp/WEB-INF/classes/portal.properties | \
     sed 's/db.host=.*/db.host=cbioportal_database:3306/g' | \
     sed 's|db.connection_string=.*|db.connection_string=jdbc:mysql://cbioportal_database:3306/|g' \
 > portal.properties

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   cbioportal:
     restart: unless-stopped
-    image: ${DOCKER_IMAGE_CBIOPORTAL:-cbioportal/cbioportal:3.4.10}
+    image: ${DOCKER_IMAGE_CBIOPORTAL}
     container_name: cbioportal_container
     environment:
       SHOW_DEBUG_INFO: "true"


### PR DESCRIPTION
Right now the `docker-compose.yml` can use a different docker image/tag while the `config/init.sh` uses a preconfigured version.
As new versions might add or remove features from the propterties-file, it might be useful to use the same image for both files.

For that I put the image that should be used to a separate `.env` file that will be automatically used by docker-compose. The `config/init.sh` requires an additional lines for parsing the parameter the `.env file` to a variable.