### PR TITLE
Set seed DB gz file name to match what docker-compose.yml expects.

### DIFF
--- a/data/init.sh
+++ b/data/init.sh
@@ -1,2 +1,2 @@
 # Download the seed database
-wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v2.0.0/db-scripts/src/main/resources/cgds.sql" && wget -O seed-cbioportal_hg19_v2.7.3.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.7.3.sql.gz"
+wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v2.0.0/db-scripts/src/main/resources/cgds.sql" && wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.7.3.sql.gz"


### PR DESCRIPTION
init_hg38.sh correctly names the downloaded seed.sql.gz to match what the docker-compose.yml file is expecting so that the DB gets initialized correctly. However, the init.sh file retained the ref and version numbers and so docker couldn't map the volumes correctly. This doesn't match the behavior that the docs at:
https://docs.cbioportal.org/2.1.1-deploy-with-docker-recommended/docker
Changing the downloaded file name to match yields the expected/documented behavior.