### PR TITLE
Update commands to remove container after run

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker-compose up
 ```
 In a different terminal import a study
 ```
-docker-compose run cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
+docker-compose run --rm cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
 ```
 
 Restart the cbioportal container after importing:
@@ -45,7 +45,7 @@ When loading hg38 data make sure to set `reference_genome_id: hg38` in [meta_stu
 ## Example Commands
 ### Connect to the database
 ```
-docker-compose run cbioportal_database \
+docker-compose run --rm cbioportal_database \
     sh -c 'mysql -hcbioportal_database -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
 ```
 


### PR DESCRIPTION
With the current commands, a new container is created after importing studies or attaching to cbioportal database. The `--rm` option will remove the container after importing a study or attaching to the db.