### PR TITLE
fixed variable name typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Followed by:
 ```
 docker-compose up
 ```
-When loading hg38 data make sure to set `reference_genome_id: hg38` in [meta_study.txt](https://docs.cbioportal.org/5.1-data-loading/data-loading/file-formats#meta-file-4). The example study in `study/` is `hg19` based. 
+When loading hg38 data make sure to set `reference_genome: hg38` in [meta_study.txt](https://docs.cbioportal.org/5.1-data-loading/data-loading/file-formats#meta-file-4). The example study in `study/` is `hg19` based. 
 
 ## Example Commands
 ### Connect to the database


### PR DESCRIPTION
One additional suggestions (which I can not request):

The "reference_genome" is marked as optional in the files formats information site, but for hg38 it will not work without this information ("specified reference genome does not correspond with the reference genome"). 
This is probably due to the fact, that there are some hard-coded lines in the docker-compose portal.properties:
ncbi.build=37
ucsc.build=hg19

So it would be great to either grep a different hg38 portal.properties file during init or automatically modify the existing one. 

This will probably be the same for mouse some day. 