### PR TITLE
Remove underscores in service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ When loading hg38 data make sure to set `reference_genome: hg38` in [meta_study.
 ## Example Commands
 ### Connect to the database
 ```
-docker-compose run --rm cbioportal_database \
-    sh -c 'mysql -hcbioportal_database -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
+docker-compose run --rm cbioportal-database \
+    sh -c 'mysql -hcbioportal-database -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
 ```
 
 ## Advanced topics

--- a/config/init.sh
+++ b/config/init.sh
@@ -5,6 +5,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | cut -d '=' -f 2-)
 
 docker run --rm -it $VERSION cat /cbioportal-webapp/WEB-INF/classes/portal.properties | \
-    sed 's/db.host=.*/db.host=cbioportal_database:3306/g' | \
-    sed 's|db.connection_string=.*|db.connection_string=jdbc:mysql://cbioportal_database:3306/|g' \
+    sed 's/db.host=.*/db.host=cbioportal-database:3306/g' | \
+    sed 's|db.connection_string=.*|db.connection_string=jdbc:mysql://cbioportal-database:3306/|g' \
 > portal.properties

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   cbioportal:
     restart: unless-stopped
     image: ${DOCKER_IMAGE_CBIOPORTAL}
-    container_name: cbioportal_container
+    container_name: cbioportal-container
     environment:
       SHOW_DEBUG_INFO: "true"
     ports:
@@ -13,15 +13,15 @@ services:
      - ./study:/study/
      - ./config/portal.properties:/cbioportal/portal.properties:ro
     depends_on:
-     - cbioportal_database
-     - cbioportal_session
+     - cbioportal-database
+     - cbioportal-session
     networks:
      - cbio-net
-    command: /bin/sh -c "java -Xms2g -Xmx4g -Dauthenticate=noauthsessionservice -Dsession.service.url=http://cbioportal_session:5000/api/sessions/my_portal/ -jar webapp-runner.jar -AmaxHttpHeaderSize=16384 -AconnectionTimeout=20000 --enable-compression /cbioportal-webapp"
-  cbioportal_database:
+    command: /bin/sh -c "java -Xms2g -Xmx4g -Dauthenticate=noauthsessionservice -Dsession.service.url=http://cbioportal-session:5000/api/sessions/my_portal/ -jar webapp-runner.jar -AmaxHttpHeaderSize=16384 -AconnectionTimeout=20000 --enable-compression /cbioportal-webapp"
+  cbioportal-database:
     restart: unless-stopped
     image: mysql:5.7
-    container_name: cbioportal_database_container
+    container_name: cbioportal-database-container
     environment:
       MYSQL_DATABASE: cbioportal
       MYSQL_USER: cbio_user
@@ -33,21 +33,21 @@ services:
      - cbioportal_mysql_data:/var/lib/mysql
     networks:
      - cbio-net
-  cbioportal_session:
+  cbioportal-session:
     restart: unless-stopped
     image: cbioportal/session-service:0.2.0
-    container_name: cbioportal_session_container
+    container_name: cbioportal-session-container
     environment:
       SERVER_PORT: 5000
-      JAVA_OPTS: -Dspring.data.mongodb.uri=mongodb://cbioportal_session_database:27017/session-service
+      JAVA_OPTS: -Dspring.data.mongodb.uri=mongodb://cbioportal-session-database:27017/session-service
     depends_on:
-      - cbioportal_session_database
+      - cbioportal-session-database
     networks:
       - cbio-net
-  cbioportal_session_database:
+  cbioportal-session-database:
     restart: unless-stopped
     image: mongo:3.7.9
-    container_name: cbioportal_session_database_container
+    container_name: cbioportal-session-database-container
     environment:
       MONGO_INITDB_DATABASE: session_service
     volumes:


### PR DESCRIPTION
Underscores in service names interfere with use as host name on tomcat (see for instance [here](https://forums.docker.com/t/underscore-in-domain-names/12584)). I had the same issue when setting up the services for the e2e-localdb tests. This PR replaces all underscores with dashes so that the problem never occurs.

![image](https://user-images.githubusercontent.com/745885/105623747-6c0fc480-5e1c-11eb-9ae3-a55a319e1df5.png)
