### PR TITLE
Fixed study directories to avoid nesting

### DIFF
--- a/study/init.sh
+++ b/study/init.sh
@@ -5,8 +5,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 DATAHUB_STUDIES="${DATAHUB_STUDIES:-lgg_ucsf_2014}"
 for study in ${DATAHUB_STUDIES}; do
-    mkdir -p ${study} && \
-        cd ${study} && \
         wget -O ${study}.tar.gz "https://cbioportal-datahub.s3.amazonaws.com/${study}.tar.gz"
         tar xvfz ${study}.tar.gz
 done


### PR DESCRIPTION
At the moment, the `init.sh` script in the `study/ `directory currently:
- creates a subdirectory for each study
- downloads an archive of compressed study data
- decompresses the archive

However, the decompression step creates an additional subdirectory.
For example, the data files for the default study (lgg_ucsf_2014) are stored in the following directory:
/study/lgg_ucsf_2014/lgg_ucsf_2014

This is probably not what was intended, and causes the metaImport.py command to fail when used with the path suggested in both the readme and the documentation (https://docs.cbioportal.org/2.1.1-deploy-with-docker-recommended/docker)

This fix avoids the extra directory by relying on the decompression step to create a subdirectory, rather than explicitly creating a subdirectory for each study.