### PR TITLE
Upgrade to new version of Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker compose -f docker-compose.yml -f open-db-ports.yml up
 ```
 In a different terminal import a study
 ```
-docker compose run --rm cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
+docker compose exec cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
 ```
 
 Restart the cbioportal container after importing:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker compose -f docker-compose.yml -f open-db-ports.yml up
 ```
 In a different terminal import a study
 ```
-docker compose run cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
+docker compose run --rm cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
 ```
 
 Restart the cbioportal container after importing:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ When loading hg38 data make sure to set `reference_genome: hg38` in [meta_study.
 ## Example Commands
 ### Connect to the database
 ```
-docker compose run --rm cbioportal-database \
+docker compose exec cbioportal-database \
     sh -c 'mysql -hcbioportal-database -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,33 +8,33 @@ datahub):
 Start docker containers. This can take a few minutes the first time because the
 database needs to import some data.
 ```
-docker-compose up
+docker compose up
 ```
 If you are developing and want to expose the database for inspection through a program like Sequel Pro, run:
 ```
-docker-compose -f docker-compose.yml -f open-db-ports.yml up
+docker compose -f docker-compose.yml -f open-db-ports.yml up
 ```
 In a different terminal import a study
 ```
-docker-compose run --rm cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
+docker compose run --rm cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
 ```
 
 Restart the cbioportal container after importing:
 ```
-docker-compose restart cbioportal
+docker compose restart cbioportal
 ```
 
 The compose file uses docker volumes which persist data between reboots. To completely remove all data run:
 
 ```
-docker-compose down -v
+docker compose down -v
 ```
 
 ## Loading other seed databases
 ### hg38 support
 To enable hg38 support. First delete any existing databases and containers:
 ```
-docker-compose down -v
+docker compose down -v
 ```
 Then run
 ```
@@ -42,26 +42,26 @@ init_hg38.sh
 ```
 Followed by:
 ```
-docker-compose up
+docker compose up
 ```
 When loading hg38 data make sure to set `reference_genome: hg38` in [meta_study.txt](https://docs.cbioportal.org/5.1-data-loading/data-loading/file-formats#meta-file-4). The example study in `study/` is `hg19` based. 
 
 ## Example Commands
 ### Connect to the database
 ```
-docker-compose run --rm cbioportal-database \
+docker compose run --rm cbioportal-database \
     sh -c 'mysql -hcbioportal-database -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"'
 ```
 
 ## Advanced topics
 ### Run different cBioPortal version
 
-A different version of cBioPortal can be run using docker-compose by declaring the `DOCKER_IMAGE_CBIOPORTAL`
+A different version of cBioPortal can be run using docker compose by declaring the `DOCKER_IMAGE_CBIOPORTAL`
 environmental variable. This variable can point a DockerHub image like so:
 
 ```
 export DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:3.1.0
-docker-compose up
+docker compose up
 ```
 
 which will start the v3.1.0 portal version rather than the newer default version.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker compose -f docker-compose.yml -f open-db-ports.yml up
 ```
 In a different terminal import a study
 ```
-docker compose exec cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
+docker compose run cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
 ```
 
 Restart the cbioportal container after importing:


### PR DESCRIPTION
- `docker-compose` is now `docker compose`, so rename the commands. This avoids messages like "Docker Compose is now in the Docker CLI, try `docker compose up`"
- For the run command it now says `Error response from daemon: can't create 'AutoRemove' container with restart policy`. Changed this to an `exec` command. Alternatively we can set up some separate container for importing specifically that doesn't have a restart policy