### PR TITLE
Upgrade of session-service to latest release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
      - cbio-net
   cbioportal-session:
     restart: unless-stopped
-    image: cbioportal/session-service:0.3.0
+    image: cbioportal/session-service:0.4.0
     container_name: cbioportal-session-container
     environment:
       SERVER_PORT: 5000


### PR DESCRIPTION
At the time of this writing, upgrading the session service to latest release [(session service releases)](https://github.com/cBioPortal/session-service/releases) resolves the following cbioportal backend exception when visiting the study view page:

` Request processing failed; nested exception is org.springframework.web.client.HttpClientErrorException$BadRequest: 400 Bad Request: [{"timestamp":1625582496505,"status":400,"error":"Bad Request","exception":"org.springframework.web.method.annotation.MethodArgumentTypeMismatchException","message":"valid types are: main_session, virtual_study, group, comparison_session, settings","path":"/api/sessions/my_portal/custom_data/query/fetch"}]`

