### PR TITLE
Enable setting mysql image thru env var and update mongo to v4.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:4.1.13
 DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.5.0
+DOCKER_IMAGE_MYSQL=mysql:5.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     command: /bin/sh -c "java -Xms2g -Xmx4g -Dauthenticate=noauthsessionservice -Dsession.service.url=http://cbioportal-session:5000/api/sessions/my_portal/ -jar webapp-runner.jar -AmaxHttpHeaderSize=16384 -AconnectionTimeout=20000 --enable-compression /cbioportal-webapp"
   cbioportal-database:
     restart: unless-stopped
-    image: mysql:5.7
+    image: ${DOCKER_IMAGE_MYSQL}
     container_name: cbioportal-database-container
     environment:
       MYSQL_DATABASE: cbioportal
@@ -46,7 +46,7 @@ services:
       - cbio-net
   cbioportal-session-database:
     restart: unless-stopped
-    image: mongo:3.7.9
+    image: mongo:4.2
     container_name: cbioportal-session-database-container
     environment:
       MONGO_INITDB_DATABASE: session_service


### PR DESCRIPTION
This is to allow setting the mysql database with an env variable (`DOCKER_IMAGE_MYSQL`), so localdb tests can leverage this functionality when running arm64 arch, see https://github.com/cBioPortal/cbioportal-frontend/pull/4535