### PR TITLE
Update files to match the latest official release (release v5.3.6)

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:4.1.13
-DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.5.0
+DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:5.3.6
+DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.1

--- a/data/init.sh
+++ b/data/init.sh
@@ -1,2 +1,2 @@
 # Download the seed database
-wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v3.6.10/db-scripts/src/main/resources/cgds.sql" && wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.12.8.sql.gz"
+wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v5.3.6/db-scripts/src/main/resources/cgds.sql" && wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.12.14.sql.gz"

--- a/data/init_hg38.sh
+++ b/data/init_hg38.sh
@@ -1,3 +1,3 @@
 # Download the seed database
 
-wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v3.6.10/db-scripts/src/main/resources/cgds.sql" && wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB_hg38/seed-cbioportal_hg19_hg38_v2.12.8.sql.gz"
+wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v5.3.6/db-scripts/src/main/resources/cgds.sql" && wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB_hg38/seed-cbioportal_hg19_hg38_v2.12.14.sql.gz"


### PR DESCRIPTION
Part of https://github.com/cbioportal/cbioportal/issues/10147
Release `v5.3.6`
- Update images
  - Update cbioportal image version to `v5.3.6`
  - Update cbioportal session service version to `v0.6.1`
- Update initial database
  - Update to seed database `v2.12.14`