### PR TITLE
update mysql to 8.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:6.0.15
 DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.1
-DOCKER_IMAGE_MYSQL=mysql:5.7
+DOCKER_IMAGE_MYSQL=mysql:8.0

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,7 +1,5 @@
 version: '3'
 
 services:
-  cbioportal-database:
-    image: biarms/mysql:5.7
   cbioportal-session-database:
     image: mongo:4.2


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/11022

- update env use mysql 8 image
- no longer need to use an arm-specific image for m1 as the default 8 image supports it