### PR TITLE
allow local data loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/*
 study/*
 config/portal.properties
 !*.sh
+config/application.properties

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     restart: unless-stopped
     image: ${DOCKER_IMAGE_MYSQL}
     container_name: cbioportal-database-container
+    command: --local-infile=1
     environment:
       MYSQL_DATABASE: cbioportal
       MYSQL_USER: cbio_user
@@ -59,8 +60,8 @@ services:
       - cbio-net
 
 networks:
-  cbio-net: 
-  
+  cbio-net:
+
 volumes:
   cbioportal_mysql_data:
   cbioportal_mongo_data:


### PR DESCRIPTION
Hi,

I just ran into an error while trying to load a sample study using:

```sh
docker compose exec cbioportal metaImport.py -u http://cbioportal:8080 -s study/lgg_ucsf_2014/ -o
```
This returns:

```
...
> /opt/java/openjdk/bin/java -Dspring.profiles.active=dbcp -cp /core/core-1.0.9.jar -Xms2G -Xmx8G org.mskcc.cbio.portal.scripts.ImportClinicalData --meta study/lgg_ucsf_2014/meta_clinical_sample.txt --loadMode bulkload --data study/lgg_ucsf_2014/data_clinical_sample.txt --noprogressRecaching...
Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts
10:44:08.180 [main] INFO org.mskcc.cbio.portal.util.GlobalProperties -- Attempting to read properties file: /cbioportal-webapp/application.properties
10:44:08.183 [main] INFO org.mskcc.cbio.portal.util.GlobalProperties -- Successfully read properties file
10:44:08.188 [main] INFO org.mskcc.cbio.portal.util.GlobalProperties -- Attempting to read properties file: /cbioportal-webapp/maven.properties
10:44:08.189 [main] INFO org.mskcc.cbio.portal.util.GlobalProperties -- Successfully read properties file
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
Finished recaching...
Reading data from:  /study/lgg_ucsf_2014/data_clinical_sample.txt
--> total number of lines:  62

ABORTED!
java.lang.RuntimeException: org.mskcc.cbio.portal.dao.DaoException: Loading local data is disabled; this must be enabled on both the client and server sides
at org.mskcc.cbio.portal.scripts.ImportClinicalData.run(ImportClinicalData.java:759)
at org.mskcc.cbio.portal.scripts.ConsoleRunnable.runInConsole(ConsoleRunnable.java:145)
at org.mskcc.cbio.portal.scripts.ImportClinicalData.main(ImportClinicalData.java:779)
Caused by: org.mskcc.cbio.portal.dao.DaoException: Loading local data is disabled; this must be enabled on both the client and server sides
at org.mskcc.cbio.portal.dao.MySQLbulkLoader.loadDataFromTempFileIntoDBMS(MySQLbulkLoader.java:265)
at org.mskcc.cbio.portal.dao.MySQLbulkLoader.flushAll(MySQLbulkLoader.java:96)
at org.mskcc.cbio.portal.scripts.ImportClinicalData.importData(ImportClinicalData.java:208)
at org.mskcc.cbio.portal.scripts.ImportClinicalData.run(ImportClinicalData.java:714)
... 2 more
Caused by: java.sql.SQLSyntaxErrorException: Loading local data is disabled; this must be enabled on both the client and server sides
at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120)
at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
at com.mysql.cj.jdbc.StatementImpl.executeInternal(StatementImpl.java:763)
at com.mysql.cj.jdbc.StatementImpl.execute(StatementImpl.java:648)
at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:182)
at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:182)
at org.mskcc.cbio.portal.dao.MySQLbulkLoader.loadDataFromTempFileIntoDBMS(MySQLbulkLoader.java:242)
... 5 more
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
Error occurred during data loading step. Please fix the problem and run this again to make sure study is completely loaded.
Traceback (most recent call last):
  File "/usr/local/bin/metaImport.py", line 207, in <module>
    cbioportalImporter.main(args)
  File "/core/scripts/importer/cbioportalImporter.py", line 681, in main
    process_study_directory(jvm_args, args.study_directory, args.update_generic_assay_entity)
  File "/core/scripts/importer/cbioportalImporter.py", line 402, in process_study_directory
    import_data(jvm_args, meta_filename, data_filename, update_generic_assay_entity, study_meta_dictionary[meta_filename])
  File "/core/scripts/importer/cbioportalImporter.py", line 200, in import_data
    run_java(*args)
  File "/core/scripts/importer/cbioportal_common.py", line 1040, in run_java
    raise RuntimeError('Aborting due to error while executing step.')
RuntimeError: Aborting due to error while executing step.
```

MySQL 8 no longer allows local data loading per the documentation:

By default, local_infile is disabled. (This is a change from previous versions of MySQL.) To cause the server to refuse or permit LOAD DATA LOCAL statements explicitly (regardless of how client programs and libraries are configured at build time or runtime), start mysqld with local_infile disabled or enabled. local_infile can also be set at runtime.

https://dev.mysql.com/doc/refman/8.0/en/load-data-local-security.html#:~:text=By%20default%2C,set%20at%20runtime.

Setting the option `--local-infile=1` via command in `docker-compose.yml` allows local data loading again.