### PR TITLE
Ensure consistency between init.sh and init_hg38.sh

### DIFF
--- a/init_hg38.sh
+++ b/init_hg38.sh
@@ -7,3 +7,9 @@ for d in data; do
     cd $d; ./init_hg38.sh
     cd ..
 done
+
+# add override docker file for arm64
+# see https://github.com/cBioPortal/cbioportal/issues/9829
+if [[ ! -f "docker-compose.override.yml" ]] && [[ "$(arch)" = "arm64" ]]; then
+    cp docker-compose.arm64.yml docker-compose.override.yml
+fi


### PR DESCRIPTION
## Before

init.sh

```sh
#!/usr/bin/env bash
for d in config data study; do
    cd $d; ./init.sh
    cd ..
done

# add override docker file for arm64
# see https://github.com/cBioPortal/cbioportal/issues/9829
if [[ ! -f "docker-compose.override.yml" ]] && [[ "$(arch)" = "arm64" ]]; then
    cp docker-compose.arm64.yml docker-compose.override.yml
fi
```

init_hg38.sh

```sh
#!/usr/bin/env bash
for d in config study; do
    cd $d; ./init.sh
    cd ..
done
for d in data; do
    cd $d; ./init_hg38.sh
    cd ..
done
```

## After

init_hg38.sh

```sh
#!/usr/bin/env bash
for d in config study; do
    cd $d; ./init.sh
    cd ..
done
for d in data; do
    cd $d; ./init_hg38.sh
    cd ..
done

# add override docker file for arm64
# see https://github.com/cBioPortal/cbioportal/issues/9829
if [[ ! -f "docker-compose.override.yml" ]] && [[ "$(arch)" = "arm64" ]]; then
    cp docker-compose.arm64.yml docker-compose.override.yml
fi
```
