### PR TITLE
Update init_hg38.sh for cBioPortal schema 2.13.1 and seed database

### DIFF
--- a/data/init_hg38.sh
+++ b/data/init_hg38.sh
@@ -1,3 +1,6 @@
-# Download the seed database
+#!/usr/bin/env bash
 
-wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v5.3.6/db-scripts/src/main/resources/cgds.sql" && wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seedDB_hg19_hg38_archive/seed-cbioportal_hg19_hg38_v2.12.14.sql.gz"
+# Download the schema
+wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v5.3.14/db-scripts/src/main/resources/cgds.sql"
+# Download the seed database
+wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_hg38_v2.13.1.sql.gz"


### PR DESCRIPTION
Hi

I also encountered the following problem. I am leaving a pull request as many people have likely encountered the same problem.

Thank you.

## Error when using seedDB with hg38 support

https://groups.google.com/g/cbioportal/c/AYcR960ukOY/m/ElwuCe_wAAAJ

> Srivatsan V
> 2023/10/20 23:05:58
> To: cBioPortal for Cancer Genomics Discussion Group
> Hi, I was trying to setup cbioportal with hg38 support. So I ran the init_hg38 script in 
> https://github.com/cBioPortal/cbioportal-docker-compose (we have setup cbiportal using this repo).
> the script:
> wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v5.3.6/db-scripts/src/main/resources/cgds.sql" && wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seedDB_hg19_hg38_archive/seed-cbioportal_hg19_hg38_v2.12.14.sql.gz"
> 
> downloads the seedDB with hg38 support and when I try to run `docker compose up` I get an error as show in the attached screenshot.
> 
> I didn't get any error and cbioportal works fine when I use the default init.sh script to download the seedDB without hg38 support: seed-cbioportal_hg19_v2.12.14.sql.gz
> 
> Please do help me out as our data is based on hg38 reference genome.

![image](https://github.com/user-attachments/assets/3496b87d-37f6-43f5-a2c0-646794b9d0bc)

> JJ Gao
> 2024/05/02 4:39:40
> To: Lucia C、cBioPortal for Cancer Genomics Discussion Group
> Hi Lucia,
> 
> Please download the latest seeddb for hg38 from here: https://github.com/cBioPortal/datahub/tree/master/seedDB. This should fix the issue. Please let us know if you have any additional questions.
> 
> Thanks,
> -JJ