### PR TITLE
Remove ARM64 Docker Compose override setup

### DIFF
--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,5 +1,0 @@
-version: '3'
-
-services:
-  cbioportal-session-database:
-    image: mongo:4.2

--- a/init.sh
+++ b/init.sh
@@ -3,9 +3,3 @@ for d in config data study; do
     cd $d; ./init.sh
     cd ..
 done
-
-# add override docker file for arm64
-# see https://github.com/cBioPortal/cbioportal/issues/9829
-if [[ ! -f "docker-compose.override.yml" ]] && [[ "$(arch)" = "arm64" ]]; then
-    cp docker-compose.arm64.yml docker-compose.override.yml
-fi

--- a/init_hg38.sh
+++ b/init_hg38.sh
@@ -7,9 +7,3 @@ for d in data; do
     cd $d; ./init_hg38.sh
     cd ..
 done
-
-# add override docker file for arm64
-# see https://github.com/cBioPortal/cbioportal/issues/9829
-if [[ ! -f "docker-compose.override.yml" ]] && [[ "$(arch)" = "arm64" ]]; then
-    cp docker-compose.arm64.yml docker-compose.override.yml
-fi


### PR DESCRIPTION
Hi!

Follow-up to #29.

After reviewing `docker-compose.yml` and `docker-compose.arm64.yml`, I noticed that both files specify image: mongo:4.2. It seems that nothing is being overwritten.

I tested this on a 2023 Apple M2 Mac Mini. For some reason, it appears to start up more smoothly without any overwriting.

Thank you.