### PR TITLE
automate env var loading

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
 DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:6.0.17
 DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.1
 DOCKER_IMAGE_MYSQL=mysql:8.0
+DB_MYSQL_USERNAME=cbio_user
+DB_MYSQL_PASSWORD=somepassword
+DB_MYSQL_URL='jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false\&allowPublicKeyRetrieval=true'

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ docker-compose.override.yml
 data/*
 study/*
 config/portal.properties
+config/application.properties
 !*.sh
+.idea
+.env.*

--- a/config/init.sh
+++ b/config/init.sh
@@ -4,7 +4,13 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | cut -d '=' -f 2-)
 
 docker run --rm -it $VERSION cat /cbioportal-webapp/application.properties |
-    sed 's|spring.datasource.password=.*|spring.datasource.password=somepassword|' | \
-    sed 's|spring.datasource.username=.*|spring.datasource.username=cbio_user|' | \
-    sed 's|spring.datasource.url=.*|spring.datasource.url=jdbc:mysql://cbioportal-database:3306/cbioportal?useSSL=false\&allowPublicKeyRetrieval=true|' \
+    sed "s|spring.datasource.password=.*|spring.datasource.password=$DB_MYSQL_PASSWORD|" | \
+    sed "s|spring.datasource.username=.*|spring.datasource.username=$DB_MYSQL_USERNAME|" | \
+    sed "s|spring.datasource.url=.*|spring.datasource.url=$DB_MYSQL_URL|" | \
+    sed "s|spring.datasource.mysql.username=.*|spring.datasource.mysql.username=$DB_MYSQL_USERNAME|" | \
+    sed "s|spring.datasource.mysql.password=.*|spring.datasource.mysql.password=$DB_MYSQL_PASSWORD|" | \
+    sed "s|spring.datasource.mysql.url=.*|spring.datasource.mysql.url=$DB_MYSQL_URL|" | \
+    sed "s|spring.datasource.clickhouse.username=.*|spring.datasource.clickhouse.username=$DB_CLICKHOUSE_USERNAME|" | \
+    sed "s|spring.datasource.clickhouse.password=.*|spring.datasource.clickhouse.password=$DB_CLICKHOUSE_PASSWORD|" | \
+    sed "s|spring.datasource.clickhouse.url=.*|spring.datasource.clickhouse.url=$DB_CLICKHOUSE_URL|" \
 > application.properties

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Load all environment variables
+set -o allexport
+source '.env'
+set +o allexport
+
 for d in config data study; do
     cd $d; ./init.sh
     cd ..

--- a/init.sh
+++ b/init.sh
@@ -5,6 +5,14 @@ set -o allexport
 source '.env'
 set +o allexport
 
+# Load dev environment variables
+if [ $# -ge 1 ] && [ "$1" = "--dev" ]; then
+  set -o allexport;
+  source '.env.dev';
+  set +o allexport;
+fi
+
+
 for d in config data study; do
     cd $d; ./init.sh
     cd ..


### PR DESCRIPTION
I abstracted away the environment variables to make database sources configurable. The change is backwards compatible so it shouldn't impact our current users and doesn't introduce any new changes to how our users can run it.