### PR TITLE
support non-tty env for docker run init commands

### DIFF
--- a/config/init.sh
+++ b/config/init.sh
@@ -6,7 +6,7 @@ VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | tail -n 1 | cut -d '=' -f 2-)
 # This is a hack. Docker run doesn't escape '&' but docker compose does.
 sed 's/&/\\&/g' ../.env > ../.env.temp
 
-docker run --rm -it --env-file ../.env.temp $VERSION bin/sh -c 'cat /cbioportal-webapp/application.properties |
+docker run --rm -i --env-file ../.env.temp $VERSION bin/sh -c 'cat /cbioportal-webapp/application.properties |
     sed "s|spring.datasource.password=.*|spring.datasource.password=${DB_MYSQL_PASSWORD}|" | \
     sed "s|spring.datasource.username=.*|spring.datasource.username=${DB_MYSQL_USERNAME}|" | \
     sed "s|spring.datasource.url=.*|spring.datasource.url=${DB_MYSQL_URL}|" | \

--- a/data/init.sh
+++ b/data/init.sh
@@ -5,6 +5,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | tail -n 1 | cut -d '=' -f 2-)
 
 # Get the schema
-docker run --rm -it $VERSION cat /cbioportal/db-scripts/cgds.sql > cgds.sql
+docker run --rm -i $VERSION cat /cbioportal/db-scripts/cgds.sql > cgds.sql
 # Download the seed database
 wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seedDB_hg19_archive/seed-cbioportal_hg19_v2.12.14.sql.gz"


### PR DESCRIPTION
This PR fixes a bug where the init scripts don't work in non-tty environments (e.g. github action runner machines and wsl for windows).

## Details
When the config/init.sh or data/init.sh is run in a non-tty environment, the docker run commands inside the script fail silently. Screenshot from git-action runner machine:

![Screenshot 2025-01-10 at 2 52 36 PM](https://github.com/user-attachments/assets/8d6d9fa6-f5cd-4894-8f92-02b0f9b51f81)

The init scripts don't need the tty flag to work so `-i` is better than a `-it` flag and avoids this problem.