### PR TITLE
Remove initialization for hg19 only seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ docker compose exec cbioportal-clickhouse-importer bash /workdir/sync-databases.
 docker compose restart cbioportal
 ```
 
+The example study in the `study/` directory is based on hg19. When importing hg38 data, be sure to set `reference_genome: hg38` in the [meta_study.txt](https://docs.cbioportal.org/5.1-data-loading/data-loading/file-formats#meta-file-4).
+
 ## Clickhouse Mode
 For cBioPortal instances with large cohorts (>100K samples), we developed a "Clickhouse mode" of the Study View. This mode uses Clickhouse as an additional database next to MySQL for 10x faster querying (see [video](https://www.youtube.com/watch?v=8PAJRCeycU4)). The mode is experimental and is currently used only by the public-facing [GENIE instance](https://genie.cbioportal.org). We plan to roll it out to other portals later this year (see [roadmap ticket](https://github.com/orgs/cBioPortal/projects/16?query=sort%3Aupdated-desc+is%3Aopen&pane=issue&itemId=92222076&issue=cBioPortal%7Croadmap%7C1)). Follow the steps below to run cBioPortal Docker Compose in clickhouse mode.
 1. Modify [.env](.env) to use clickhouse-compatible release of cBioPortal.
@@ -57,24 +59,6 @@ For cBioPortal instances with large cohorts (>100K samples), we developed a "Cli
     ```shell
     docker compose -f docker-compose.yml -f addon/clickhouse/docker-compose.clickhouse.yml up
     ```
-
-## Known issues
-
-## Loading other seed databases
-### hg38 support
-To enable hg38 support. First delete any existing databases and containers:
-```
-docker compose down -v
-```
-Then run
-```
-init_hg38.sh
-```
-Followed by:
-```
-docker compose up
-```
-When loading hg38 data make sure to set `reference_genome: hg38` in [meta_study.txt](https://docs.cbioportal.org/5.1-data-loading/data-loading/file-formats#meta-file-4). The example study in `study/` is `hg19` based. 
 
 ## Example Commands
 ### Connect to the database

--- a/data/init.sh
+++ b/data/init.sh
@@ -7,5 +7,5 @@ VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | tail -n 1 | cut -d '=' -f 2-)
 # Get the schema
 docker run --rm -i $VERSION cat /cbioportal/db-scripts/cgds.sql > cgds.sql
 
-# Download the seed database
-wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seedDB_hg19_archive/seed-cbioportal_hg19_v2.12.14.sql.gz"
+# Download the combined hg19 + hg38 seed database
+wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_hg38_v2.13.1.sql.gz"

--- a/data/init_hg38.sh
+++ b/data/init_hg38.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Download the schema
-wget -O cgds.sql "https://raw.githubusercontent.com/cBioPortal/cbioportal/v5.3.14/db-scripts/src/main/resources/cgds.sql"
-# Download the seed database
-wget -O seed.sql.gz "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_hg38_v2.13.1.sql.gz"

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-
-for d in config data study; do
+for d in config study data; do
     cd $d; ./init.sh
     cd ..
 done
+

--- a/init_hg38.sh
+++ b/init_hg38.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-for d in config study; do
-    cd $d; ./init.sh
-    cd ..
-done
-for d in data; do
-    cd $d; ./init_hg38.sh
-    cd ..
-done


### PR DESCRIPTION
**Issue:**
We provide both hg19 and hg38 (hg19+38) initialization options, but the datahub provides only the combined seed due to the presence of both hg19 and hg38 studies. Running `./init.sh` currently initializes only the hg19 seed, which will cause problems when importing hg38 studies.

**Solution:**
Remove the hg19-only initialization and use the combined hg19+hg38 seed instead.