### PR TITLE
Update MySQL environment variables in .env and docker-compose.yml

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,7 @@ DB_CLICKHOUSE_DB_NAME=cbioportal
 DB_CLICKHOUSE_USERNAME=cbio_user
 DB_CLICKHOUSE_PASSWORD=somepassword
 DB_CLICKHOUSE_URL=jdbc:ch://cbioportal-clickhouse-database:8123/cbioportal
+MYSQL_DATABASE=cbioportal
+MYSQL_USER=cbio_user
+MYSQL_PASSWORD=somepassword
+MYSQL_ROOT_PASSWORD=somepassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   cbioportal:
@@ -11,13 +11,13 @@ services:
     ports:
       - "8080:8080"
     volumes:
-     - ./study:/study/
-     - ${APPLICATION_PROPERTIES_PATH:-./config/application.properties}:/cbioportal-webapp/application.properties:ro
+      - ./study:/study/
+      - ${APPLICATION_PROPERTIES_PATH:-./config/application.properties}:/cbioportal-webapp/application.properties:ro
     depends_on:
-     - cbioportal-database
-     - cbioportal-session
+      - cbioportal-database
+      - cbioportal-session
     networks:
-     - cbio-net
+      - cbio-net
     # TODO: servlet-api should be excluded from deps in mvn, the removal below is just a quick fix
     # This might be helpful: https://stackoverflow.com/questions/36233626
     command: /bin/sh -c "rm -rf /cbioportal-webapp/lib/servlet-api-2.5.jar && java -Xms2g -Xmx4g -cp '/cbioportal-webapp:/cbioportal-webapp/lib/*' org.cbioportal.PortalApplication --spring.config.location=cbioportal-webapp/application.properties --authenticate=false --session.service.url=http://cbioportal-session:5001/api/sessions/my_portal/ --clickhouse_mode=$${APP_CLICKHOUSE_MODE:-false} --spring.profiles.active=$${APP_SPRING_PROFILE:-default}"
@@ -26,16 +26,16 @@ services:
     image: ${DOCKER_IMAGE_MYSQL}
     container_name: cbioportal-database-container
     environment:
-      MYSQL_DATABASE: cbioportal
-      MYSQL_USER: cbio_user
-      MYSQL_PASSWORD: somepassword
-      MYSQL_ROOT_PASSWORD: somepassword
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
-     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:ro
-     - ./data/seed.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:ro
-     - cbioportal_mysql_data:/var/lib/mysql
+      - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:ro
+      - ./data/seed.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:ro
+      - cbioportal_mysql_data:/var/lib/mysql
     networks:
-     - cbio-net
+      - cbio-net
     command: --local-infile=1
   cbioportal-session:
     restart: unless-stopped
@@ -61,7 +61,7 @@ services:
 
 networks:
   cbio-net:
-  
+
 volumes:
   cbioportal_mysql_data:
   cbioportal_mongo_data:


### PR DESCRIPTION
Closes #49

## Improved docker-compose.yml

This PR significantly improves the configuration management by:

1. Moving hardcoded values from docker-compose.yml cbioportal-database to the .env file
2. Ensuring compatibility with all existing initialization scripts

These changes make the deployment more maintainable and user-friendly by centralizing all configuration in one well-documented file, while keeping the actual implementation in docker-compose.yml unchanged.