### PR TITLE
Moving back to v6.3 Docker image version for cbioportal

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:6.4.1
+DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:6.3.7
 DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.4
 DOCKER_IMAGE_MYSQL=mysql:8.0
 DOCKER_IMAGE_CLICKHOUSE=clickhouse/clickhouse-server:24.10


### PR DESCRIPTION
We can't update until the seed database update