### PR TITLE
Add health check for cbioportal-clickhouse-database

### DIFF
--- a/addon/clickhouse/docker-compose.clickhouse.yml
+++ b/addon/clickhouse/docker-compose.clickhouse.yml
@@ -51,13 +51,13 @@ services:
       cbioportal-clickhouse-database:
         condition: service_started
       cbioportal-database:
-        condition: service_started
+        condition: service_healthy
       cbioportal-clickhouse-schema-extractor:
         condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "test", "-f", "/workdir/init-complete.txt"]
-      interval: 2m30s
-      timeout: 30s
+      interval: 10s
+      timeout: 3s
       retries: 300
     command: [ "bash", "/workdir/init.sh" ]
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
     networks:
      - cbio-net
     command: --local-infile=1
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -s -hcbioportal-database -P3306 -ucbio_user -psomepassword"]
+      interval: 10s
+      timeout: 3s
+      retries: 300
   cbioportal-session:
     restart: unless-stopped
     image: ${DOCKER_IMAGE_SESSION_SERVICE}


### PR DESCRIPTION
Add cbioportal-clickhouse-database health check to make sure that clickhouse import starts after mysql import finishes