### PR TITLE
Fix cbioportal-clickhouse-importer health check

### DIFF
--- a/addon/clickhouse/docker-compose.clickhouse.yml
+++ b/addon/clickhouse/docker-compose.clickhouse.yml
@@ -59,7 +59,6 @@ services:
       interval: 10s
       timeout: 3s
       retries: 300
-      start_period: 5m
     command: [ "bash", "/workdir/init.sh" ]
     networks:
       - cbio-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
      - cbio-net
     command: --local-infile=1
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -s -h localhost -P3306 -u $$DB_MYSQL_USERNAME -p$$DB_MYSQL_PASSWORD"]
+      test: [ "CMD-SHELL", "test 853 -eq $$(mysql -hlocalhost -P3306 -u$$MYSQL_USER -p$$MYSQL_PASSWORD -e 'SELECT COUNT(*) FROM type_of_cancer' cbioportal --skip-column-names --silent)" ]
       interval: 10s
       timeout: 3s
       retries: 300


### PR DESCRIPTION
- Improve health check by actually checking if a certain table exists and populated with correct number of rows. Current healthcheck (mysqladmin ping) prematurely returns true before the tables are populated.
- Use correct env variables (`DB_MYSQL_USERNAME` and `DB_MYSQL_PASSWORD` are empty in cbioportal-database, use `MYSQL_USER` and `MYSQL_PASSWORD` instead).