### PR TITLE
Relax brittle MySQL healthcheck in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
      - cbio-net
     command: --local-infile=1
     healthcheck:
-      test: [ "CMD-SHELL", "test 853 -eq $$(mysql -hlocalhost -P3306 -u$$MYSQL_USER -p$$MYSQL_PASSWORD -e 'SELECT COUNT(*) FROM type_of_cancer' cbioportal --skip-column-names --silent)" ]
+      test: [ "CMD-SHELL", "test $$(mysql -hlocalhost -P3306 -u$$MYSQL_USER -p$$MYSQL_PASSWORD -e 'SELECT COUNT(*) FROM type_of_cancer' cbioportal --skip-column-names --silent) -gt 0" ]
       interval: 10s
       timeout: 3s
       retries: 300


### PR DESCRIPTION
Fixes #73

The MySQL healthcheck currently depends on a fixed row count in `type_of_cancer`, which can cause the container to remain in `health: starting` even when MySQL is ready.

This PR replaces the strict equality check with a condition that does not depend on a specific dataset size.

## Changes

- Updated MySQL healthcheck to remove dependency on exact row count
- Healthcheck now verifies that the database is initialized instead of matching a fixed value

## Testing

- Ran full `init.sh` + ClickHouse compose flow
- Verified MySQL reaches `healthy`
- Verified dependent services (e.g. `cbioportal-clickhouse-importer`) start correctly