### PR TITLE
Add logic to pull study_es_0 and required gene panels in study/init.sh

### DIFF
--- a/study/init.sh
+++ b/study/init.sh
@@ -8,7 +8,6 @@ VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL "${SCRIPT_DIR}/../.env" | tail -n 1 | cut
 CONTAINER=$(docker create "$VERSION")
 trap 'docker rm $CONTAINER' EXIT
 docker cp "$CONTAINER:/cbioportal/test/study_es_0" "${SCRIPT_DIR}/study_es_0"
-rm -f "${SCRIPT_DIR}"/study_es_0/*_gsva_*
 
 # Download datahub studies
 DATAHUB_STUDIES="${DATAHUB_STUDIES:-lgg_ucsf_2014 msk_impact_2017}"

--- a/study/init.sh
+++ b/study/init.sh
@@ -3,17 +3,19 @@ set -eo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Pull study_es_0 out of the cBioPortal image
-VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL "${SCRIPT_DIR}/../.env" | tail -n 1 | cut -d '=' -f 2-)
-CONTAINER=$(docker create "$VERSION")
-trap 'docker rm $CONTAINER' EXIT
-docker cp "$CONTAINER:/cbioportal/test/study_es_0" "${SCRIPT_DIR}/study_es_0"
+# Clone cbioportal repo (shallow) and pull study_es_0 and genesets from it
+CBIO_REPO="${SCRIPT_DIR}/cbioportal"
+trap 'rm -rf "$CBIO_REPO"' EXIT
+git clone --depth 1 https://github.com/cBioPortal/cbioportal.git "$CBIO_REPO"
+rm -rf "${SCRIPT_DIR}/study_es_0"
+cp -r "$CBIO_REPO/test/test_data/study_es_0" "${SCRIPT_DIR}/study_es_0"
 
 # Download datahub studies
 DATAHUB_STUDIES="${DATAHUB_STUDIES:-lgg_ucsf_2014 msk_impact_2017}"
 for study in ${DATAHUB_STUDIES}; do
     curl -fL -o "${study}.tar.gz" "https://datahub.assets.cbioportal.org/${study}.tar.gz"
     tar xfz "${study}.tar.gz"
+    rm "${study}.tar.gz"
 done
 
 # Collect gene panel reference data
@@ -29,8 +31,5 @@ for panel in data_gene_panel_impact341.txt data_gene_panel_impact410.txt; do
     curl -fL -o "${SCRIPT_DIR}/reference_data/${panel}" "${PANEL_BASE}/${panel}"
 done
 
-# Download genesets for study_es_0
-GENESET_BASE="https://raw.githubusercontent.com/cBioPortal/cbioportal-core/refs/heads/main/src/test/resources/genesets"
-for f in study_es_0_genesets.gmt study_es_0_tree.yaml study_es_0_supp-genesets.txt; do
-    curl -fL -o "${SCRIPT_DIR}/reference_data/${f}" "${GENESET_BASE}/${f}"
-done
+# Copy genesets from cloned repo
+cp "$CBIO_REPO/test/test_data/genesets/"* "${SCRIPT_DIR}/reference_data/"

--- a/study/init.sh
+++ b/study/init.sh
@@ -8,6 +8,7 @@ VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL "${SCRIPT_DIR}/../.env" | tail -n 1 | cut
 CONTAINER=$(docker create "$VERSION")
 trap 'docker rm $CONTAINER' EXIT
 docker cp "$CONTAINER:/cbioportal/test/study_es_0" "${SCRIPT_DIR}/study_es_0"
+rm -f "${SCRIPT_DIR}"/study_es_0/*_gsva_*
 
 # Download datahub studies
 DATAHUB_STUDIES="${DATAHUB_STUDIES:-lgg_ucsf_2014 msk_impact_2017}"

--- a/study/init.sh
+++ b/study/init.sh
@@ -1,10 +1,30 @@
 #!/usr/bin/env bash
-# download data hub study and import
+set -eo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# Pull study_es_0 out of the cBioPortal image
+VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL "${SCRIPT_DIR}/../.env" | tail -n 1 | cut -d '=' -f 2-)
+CONTAINER=$(docker create "$VERSION")
+trap 'docker rm $CONTAINER' EXIT
+docker cp "$CONTAINER:/cbioportal/test/study_es_0" "${SCRIPT_DIR}/study_es_0"
+
+# Download datahub studies
 DATAHUB_STUDIES="${DATAHUB_STUDIES:-lgg_ucsf_2014 msk_impact_2017}"
 for study in ${DATAHUB_STUDIES}; do
-        curl -fL -o "${study}.tar.gz" "https://datahub.assets.cbioportal.org/${study}.tar.gz"
-        tar xvfz ${study}.tar.gz
+    curl -fL -o "${study}.tar.gz" "https://datahub.assets.cbioportal.org/${study}.tar.gz"
+    tar xfz "${study}.tar.gz"
+done
+
+# Collect gene panel reference data
+mkdir -p "${SCRIPT_DIR}/reference_data"
+
+# Copy test panels bundled with study_es_0
+cp "${SCRIPT_DIR}/study_es_0/data_gene_panel_testpanel1.txt" "${SCRIPT_DIR}/reference_data/"
+cp "${SCRIPT_DIR}/study_es_0/data_gene_panel_testpanel2.txt" "${SCRIPT_DIR}/reference_data/"
+
+# Download IMPACT panels from datahub
+PANEL_BASE="https://media.githubusercontent.com/media/cBioPortal/datahub/refs/heads/master/reference_data/gene_panels"
+for panel in data_gene_panel_impact341.txt data_gene_panel_impact410.txt; do
+    curl -fL -o "${SCRIPT_DIR}/reference_data/${panel}" "${PANEL_BASE}/${panel}"
 done

--- a/study/init.sh
+++ b/study/init.sh
@@ -28,3 +28,9 @@ PANEL_BASE="https://media.githubusercontent.com/media/cBioPortal/datahub/refs/he
 for panel in data_gene_panel_impact341.txt data_gene_panel_impact410.txt; do
     curl -fL -o "${SCRIPT_DIR}/reference_data/${panel}" "${PANEL_BASE}/${panel}"
 done
+
+# Download genesets for study_es_0
+GENESET_BASE="https://raw.githubusercontent.com/cBioPortal/cbioportal-core/refs/heads/main/src/test/resources/genesets"
+for f in study_es_0_genesets.gmt study_es_0_tree.yaml study_es_0_supp-genesets.txt; do
+    curl -fL -o "${SCRIPT_DIR}/reference_data/${f}" "${GENESET_BASE}/${f}"
+done


### PR DESCRIPTION
NOTE: this PR is against the RC branch

We pull the study_es_0 outside of the cbioportal docker image

still getting a geneset error due to a mismatch between what's defined in the meta GSVA files and the database's geneses version. This needs to be addressed prior to merge.