### PR TITLE
Restore remote-ClickHouse compose override

### DIFF
--- a/addon/clickhouse/docker-compose.remote.clickhouse.yml
+++ b/addon/clickhouse/docker-compose.remote.clickhouse.yml
@@ -1,0 +1,34 @@
+# Point cBioPortal at an EXTERNAL / remote ClickHouse instead of the bundled local one.
+#
+# Usage (as a compose extension, applied last so it wins the merge):
+#   docker compose -f docker-compose.yml \
+#                  -f dev/docker-compose.web.yml \
+#                  -f addon/clickhouse/docker-compose.remote.clickhouse.yml up
+#
+# Connection settings are read from the shell environment (e.g. a CI context such as
+# `clickhouse-public-staging-ro-user`) and override the local defaults baked into .env.
+# Required env vars: CLICKHOUSE_URL, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD.
+#
+# This restores the pre-v7 `docker-compose.remote.clickhouse.yml` (deleted in the
+# "import to ClickHouse" refactor), adapted to the v7 base compose where ClickHouse
+# is the local default DB.
+services:
+  cbioportal:
+    # `environment` takes precedence over `env_file` (.env), so these point the running
+    # container at the remote ClickHouse instead of jdbc:ch://cbioportal-database:8123.
+    environment:
+      CLICKHOUSE_URL: ${CLICKHOUSE_URL}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+    # Don't wait on (or require) the local DB healthcheck — we're talking to a remote DB.
+    # `!override` replaces the base mapping rather than merging into it.
+    depends_on: !override
+      cbioportal-session:
+        condition: service_started
+    # The base entrypoint injects application.properties into the importer JAR, which is
+    # only present in the web-and-data image. Bypass it; `command` runs the web app.jar.
+    entrypoint: []
+  # Do not start the bundled local ClickHouse at all.
+  cbioportal-database:
+    deploy:
+      replicas: 0

--- a/addon/clickhouse/docker-compose.remote.clickhouse.yml
+++ b/addon/clickhouse/docker-compose.remote.clickhouse.yml
@@ -17,9 +17,9 @@ services:
     # `environment` takes precedence over `env_file` (.env), so these point the running
     # container at the remote ClickHouse instead of jdbc:ch://cbioportal-database:8123.
     environment:
-      CLICKHOUSE_URL: ${CLICKHOUSE_URL}
-      CLICKHOUSE_USER: ${CLICKHOUSE_USER}
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD}
+      CLICKHOUSE_URL: ${CLICKHOUSE_URL:?CLICKHOUSE_URL is required}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:?CLICKHOUSE_USER is required}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
     # Don't wait on (or require) the local DB healthcheck — we're talking to a remote DB.
     # `!override` replaces the base mapping rather than merging into it.
     depends_on: !override


### PR DESCRIPTION
The v7 "import to ClickHouse" refactor (5f05885) deleted `addon/clickhouse/docker-compose.remote.clickhouse.yml`, which let a portal point at an external ClickHouse without standing up or waiting on a local DB. Its removal broke every downstream CI job that brings up the stack:

- **`run_api_tests`** — the `cbioportal` service in the v7 base compose gates on `depends_on: cbioportal-database: condition: service_healthy`. The local ClickHouse never seeds in CI (the schema/seed init fails), so the healthcheck never passes and the portal container is never started — `:8080` never comes up and the API suite times out before running.
- **`run_e2e_localdb_tests`** — still passes `-f addon/clickhouse/docker-compose.remote.clickhouse.yml`, which now 404s, so compose errors out immediately.

This restores the override, adapted to the v7 base compose:

- `depends_on: !override` → only `cbioportal-session` (drops the local-DB health gate)
- `cbioportal-database: deploy.replicas: 0` (don't start the bundled local DB)
- `entrypoint: []` (the v7 entrypoint injects `application.properties` into the importer JAR, which only exists in the web-and-data image)
- `environment: CLICKHOUSE_URL/USER/PASSWORD`, which take precedence over `env_file` (`.env`) so the container points at the remote DB. (`.env` hardcodes `CLICKHOUSE_URL=jdbc:ch://cbioportal-database:8123`, and `cbioportal-test`'s `docker-compose.sh` only propagates `^DOCKER|^DB|^APP` vars into `.env`, so the CI context creds otherwise never reach the container.)

Verified locally with `docker compose ... config`: the merged `cbioportal` service drops the DB dependency, takes the remote `CLICKHOUSE_URL`, clears the entrypoint, and `cbioportal-database` resolves to `replicas: 0`.

### Companion change required
This file alone fully fixes only the e2e job (which already references the path). For **`run_api_tests`** to use it, the main `cbioportal` repo's `.circleci/config.yml` needs `--compose_extensions='-f addon/clickhouse/docker-compose.remote.clickhouse.yml'` added to the "Instantiate a cbioportal instance" step (separate PR).

### Assumption
The `clickhouse-public-staging-ro-user` context must export `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD` pointing at a populated staging DB. If the context uses different names, the `environment:` keys must match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)