### PR TITLE
Wire ClickHouse schema migration runner into docker compose up

### DIFF
--- a/data/init.sh
+++ b/data/init.sh
@@ -10,4 +10,8 @@ trap 'docker rm $CONTAINER' EXIT
 
 docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/init/schema.sql "${SCRIPT_DIR}/schema.sql"
 docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/init/seed-cbioportal_hg19_hg38_v2.14.5.sql.gz "${SCRIPT_DIR}/seed.sql.gz"
-docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/clickhouse.sql "${SCRIPT_DIR}/clickhouse.sql"
+docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/generate_derived_tables.sql "${SCRIPT_DIR}/generate_derived_tables.sql"
+# migrate_schema.sql / migrate_db.py are NOT extracted here: the migration-runner service in
+# docker-compose.yml runs them directly from inside the cbioportal image (which already has
+# python3 + a clickhouse client, and already bundles db-scripts/clickhouse/migrate/), instead of
+# from a host-mounted copy.

--- a/data/init.sh
+++ b/data/init.sh
@@ -10,7 +10,7 @@ trap 'docker rm $CONTAINER' EXIT
 
 docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/init/schema.sql "${SCRIPT_DIR}/schema.sql"
 docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/init/seed-cbioportal_hg19_hg38_v2.14.5.sql.gz "${SCRIPT_DIR}/seed.sql.gz"
-docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/generate_derived_tables.sql "${SCRIPT_DIR}/generate_derived_tables.sql"
+docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/populate_derived_tables.sql "${SCRIPT_DIR}/populate_derived_tables.sql"
 # migrate_schema.sql / migrate_db.py are NOT extracted here: the migration-runner service in
 # docker-compose.yml runs them directly from inside the cbioportal image (which already has
 # python3 + a clickhouse client, and already bundles db-scripts/clickhouse/migrate/), instead of

--- a/data/load_derived_tables.sh
+++ b/data/load_derived_tables.sh
@@ -8,5 +8,5 @@ clickhouse-client \
     --database "${CLICKHOUSE_DB}" \
     --multiquery \
     --param_optimize_backoff_secs="${CLICKHOUSE_OPTIMIZE_BACKOFF_SECS:-0}" \
-    < /data/clickhouse.sql
+    < /data/generate_derived_tables.sql
 echo "Successfully created derived tables."

--- a/data/load_derived_tables.sh
+++ b/data/load_derived_tables.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -eo pipefail
 
-echo "Creating derived tables..."
+echo "Populating derived tables..."
 clickhouse-client \
     --user "${CLICKHOUSE_USER}" \
     --password "${CLICKHOUSE_PASSWORD}" \
     --database "${CLICKHOUSE_DB}" \
     --multiquery \
     --param_optimize_backoff_secs="${CLICKHOUSE_OPTIMIZE_BACKOFF_SECS:-0}" \
-    < /data/generate_derived_tables.sql
-echo "Successfully created derived tables."
+    < /data/populate_derived_tables.sql
+echo "Successfully populated derived tables."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,12 @@ services:
       - ${APPLICATION_PROPERTIES_PATH:-./config/application.properties}:/cbioportal-webapp/application.properties:ro
       # We need to mount the derived table script into the cbioportal container
       # The metaImport script looks for it under $PORTAL_HOME
-      - ./data/clickhouse.sql:/cbioportal/clickhouse.sql:ro
+      - ./data/generate_derived_tables.sql:/cbioportal/generate_derived_tables.sql:ro
     depends_on:
       cbioportal-database:
         condition: service_healthy
+      cbioportal-migration:
+        condition: service_completed_successfully
       cbioportal-session:
         condition: service_started
     networks:
@@ -41,7 +43,7 @@ services:
       - ./data/load_schema.sh:/docker-entrypoint-initdb.d/001_load_schema.sh:ro
       - ./data/seed.sql.gz:/data/seed.sql.gz:ro
       - ./data/load_seed.sh:/docker-entrypoint-initdb.d/002_load_seed.sh:ro
-      - ./data/clickhouse.sql:/data/clickhouse.sql:ro
+      - ./data/generate_derived_tables.sql:/data/generate_derived_tables.sql:ro
       - ./data/load_derived_tables.sh:/docker-entrypoint-initdb.d/003_load_derived_tables.sh:ro
       - cbioportal_clickhouse_data:/var/lib/clickhouse
     networks:
@@ -52,6 +54,24 @@ services:
       timeout: 3s
       retries: 300
       start_period: 5m
+
+  # Applies any pending base-table schema migrations (db-scripts/clickhouse/migrate/migrate_schema.sql,
+  # via migrate_db.py) before the cbioportal app starts. On a fresh install this is a no-op, since
+  # schema.sql already seeds `info` at the current db_schema_version. Runs from the cbioportal image
+  # itself (not a host-mounted script) since that image already bundles python3, a clickhouse client,
+  # and db-scripts/clickhouse/migrate/.
+  cbioportal-migration:
+    image: ${DOCKER_IMAGE_CBIOPORTAL}
+    container_name: cbioportal-migration-container
+    env_file:
+      - .env
+    depends_on:
+      cbioportal-database:
+        condition: service_healthy
+    networks:
+      - cbio-net
+    entrypoint: ["python3", "/cbioportal/db-scripts/clickhouse/migrate/migrate_db.py"]
+    restart: "no"
 
   cbioportal-session:
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,8 @@ services:
   # schema.sql already seeds `info` at the current db_schema_version. Runs from the cbioportal image
   # itself (not a host-mounted script) since that image already bundles python3, a clickhouse client,
   # and db-scripts/clickhouse/migrate/. --regenerate-derived-tables also regenerates derived tables
-  # whenever generate_derived_tables.sql's version differs from the database's current
-  # derived_table_schema_version, so docker-compose users get this for free with no manual step.
+  # automatically whenever generate_derived_tables.sql's version differs from the database's
+  # current derived_table_schema_version, so docker-compose users don't need a manual step.
   cbioportal-migration:
     image: ${DOCKER_IMAGE_CBIOPORTAL}
     container_name: cbioportal-migration-container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,9 @@ services:
   # via migrate_db.py) before the cbioportal app starts. On a fresh install this is a no-op, since
   # schema.sql already seeds `info` at the current db_schema_version. Runs from the cbioportal image
   # itself (not a host-mounted script) since that image already bundles python3, a clickhouse client,
-  # and db-scripts/clickhouse/migrate/.
+  # and db-scripts/clickhouse/migrate/. --regenerate-derived-tables also regenerates derived tables
+  # whenever generate_derived_tables.sql's version differs from the database's current
+  # derived_table_schema_version, so docker-compose users get this for free with no manual step.
   cbioportal-migration:
     image: ${DOCKER_IMAGE_CBIOPORTAL}
     container_name: cbioportal-migration-container
@@ -70,7 +72,7 @@ services:
         condition: service_healthy
     networks:
       - cbio-net
-    entrypoint: ["python3", "/cbioportal/db-scripts/clickhouse/migrate/migrate_db.py"]
+    entrypoint: ["python3", "/cbioportal/db-scripts/clickhouse/migrate/migrate_db.py", "--regenerate-derived-tables"]
     restart: "no"
 
   cbioportal-session:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ${APPLICATION_PROPERTIES_PATH:-./config/application.properties}:/cbioportal-webapp/application.properties:ro
       # We need to mount the derived table script into the cbioportal container
       # The metaImport script looks for it under $PORTAL_HOME
-      - ./data/generate_derived_tables.sql:/cbioportal/generate_derived_tables.sql:ro
+      - ./data/populate_derived_tables.sql:/cbioportal/populate_derived_tables.sql:ro
     depends_on:
       cbioportal-database:
         condition: service_healthy
@@ -43,7 +43,7 @@ services:
       - ./data/load_schema.sh:/docker-entrypoint-initdb.d/001_load_schema.sh:ro
       - ./data/seed.sql.gz:/data/seed.sql.gz:ro
       - ./data/load_seed.sh:/docker-entrypoint-initdb.d/002_load_seed.sh:ro
-      - ./data/generate_derived_tables.sql:/data/generate_derived_tables.sql:ro
+      - ./data/populate_derived_tables.sql:/data/populate_derived_tables.sql:ro
       - ./data/load_derived_tables.sh:/docker-entrypoint-initdb.d/003_load_derived_tables.sh:ro
       - cbioportal_clickhouse_data:/var/lib/clickhouse
     networks:
@@ -59,9 +59,9 @@ services:
   # via migrate_db.py) before the cbioportal app starts. On a fresh install this is a no-op, since
   # schema.sql already seeds `info` at the current db_schema_version. Runs from the cbioportal image
   # itself (not a host-mounted script) since that image already bundles python3, a clickhouse client,
-  # and db-scripts/clickhouse/migrate/. --regenerate-derived-tables also regenerates derived tables
-  # automatically whenever generate_derived_tables.sql's version differs from the database's
-  # current derived_table_schema_version, so docker-compose users don't need a manual step.
+  # and db-scripts/clickhouse/migrate/. --populate-derived-tables also repopulates derived tables
+  # automatically whenever this run actually applies one or more migrations, so docker-compose
+  # users don't need a manual step.
   cbioportal-migration:
     image: ${DOCKER_IMAGE_CBIOPORTAL}
     container_name: cbioportal-migration-container
@@ -72,7 +72,7 @@ services:
         condition: service_healthy
     networks:
       - cbio-net
-    entrypoint: ["python3", "/cbioportal/db-scripts/clickhouse/migrate/migrate_db.py", "--regenerate-derived-tables"]
+    entrypoint: ["python3", "/cbioportal/db-scripts/clickhouse/migrate/migrate_db.py", "--populate-derived-tables"]
     restart: "no"
 
   cbioportal-session:


### PR DESCRIPTION
## Summary

Wires the new ClickHouse schema migration runner (added in the companion `cbioportal` PR,
`clickhouse-migration-mechanism`) into `docker compose up`, so upgrading is `git pull` + `docker
compose up` with no manual steps.

- Adds a `cbioportal-migration` service that runs `migrate_db.py` after `cbioportal-database` is
  healthy and before the `cbioportal` app service starts. This runs on **every** `docker compose
  up`, not just fresh init — `docker-entrypoint-initdb.d` scripts only fire once against an empty
  volume, so a separate always-run step is required to handle upgrades.
- Runs `migrate_db.py` directly from the `${DOCKER_IMAGE_CBIOPORTAL}` image rather than a
  host-mounted script or a new custom image: that image already bundles python3, a static
  `clickhouse` client binary (for the core importer), and now bundles
  `db-scripts/clickhouse/migrate/` too.
- Passes `--populate-derived-tables`, so derived tables are automatically repopulated whenever a
  run actually applies one or more pending migrations — no separate manual step for Docker
  Compose users.
- On a fresh install this is a safe no-op, since `schema.sql` already seeds `info` at the current
  `db_schema_version`.
- Renames local `data/clickhouse.sql` references to `data/generate_derived_tables.sql`, then to
  `data/populate_derived_tables.sql`, matching the rename on the `cbioportal` side (that script is
  now data-population only — derived table structure moved into `schema.sql`).

Depends on the `cbioportal` PR (`clickhouse-migration-mechanism`) for `migrate_schema.sql` /
`migrate_db.py` / `populate_derived_tables.sql` to exist in the image.

## Test plan

- [x] `docker-compose.yml` YAML syntax validated
- [x] Needs a real run before merge:
  - [x] Fresh install: `docker compose up` completes, `cbioportal-migration` exits 0 as a no-op
  - [x] Upgrade: bring up an old-tagged stack, bump `.env`'s `DOCKER_IMAGE_CBIOPORTAL` tag to one
        built from the companion `cbioportal` branch, `docker compose up` again, confirm
        `cbioportal-migration` runs the `3.0.0` section, repopulates derived tables, and the app
        starts afterward
  - [x] Confirm `cbioportal` service correctly waits on `cbioportal-migration`'s
        `service_completed_successfully` before starting