### PR TITLE
Fix `jar: command not found` on startup with cbioportal v7.0.1+

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,30 @@
 #!/bin/bash
 set -eo pipefail
 
-## Inject application.properties into the importer JAR so it overrides the bundled one
-cd /tmp && cp /cbioportal-webapp/application.properties . && jar uf /core/core-IMPORTER.jar application.properties
+## Inject application.properties into the importer JAR so it overrides the bundled one.
+## The cbioportal image ships a JRE only, so the archive is updated with python3's
+## zipfile module rather than the JDK's `jar` tool.
+python3 - <<'PY'
+import os
+import zipfile
+
+JAR = "/core/core-IMPORTER.jar"
+ENTRY = "application.properties"
+STAGED_JAR = JAR + ".staged"
+
+with open("/cbioportal-webapp/application.properties", "rb") as properties_file:
+    properties = properties_file.read()
+
+with zipfile.ZipFile(JAR) as jar:
+    if ENTRY in jar.namelist() and jar.read(ENTRY) == properties:
+        raise SystemExit(0)
+    with zipfile.ZipFile(STAGED_JAR, "w") as staged_jar:
+        for member in jar.infolist():
+            if member.filename != ENTRY:
+                staged_jar.writestr(member, jar.read(member))
+        staged_jar.writestr(ENTRY, properties, zipfile.ZIP_DEFLATED)
+
+os.replace(STAGED_JAR, JAR)
+PY
 
 exec "$@"


### PR DESCRIPTION
Fixes #87.

## Problem

Fresh installs on v7.0.1+ never start — the entrypoint aborts before `exec "$@"`:

```
/cbioportal/entrypoint.sh: line 5: jar: command not found
```

`jar` is a JDK tool. The cbioportal image shipped a JDK through v7.0.0, but from
v7.0.1 it ships only a JRE:

```
$ docker run --rm --entrypoint /bin/sh cbioportal/cbioportal:7.0.2 -c 'ls /opt/java/openjdk/bin'
java  jfr  jrunscript  jwebserver  keytool  rmiregistry
```

## Fix

`jar uf` just replaces an entry in a zip file, so the same update is done with
python3's `zipfile` module — python3 is already in the image (the importer
scripts are written in it), so this adds no dependency.

The injection itself is still needed: the importer resolves `application.properties`
off the classpath, and every entry point (`scripts/*.pl`, `cbioportalImporter.py`)
hardcodes `-cp <core-*.jar>` with no way to prepend an external directory.
Setting `PORTAL_HOME` to a directory holding the file does not work either —
verified against the shipped jar, the datasource stays unconfigured.

Two small improvements over the previous one-liner:

- the properties are compared before rewriting, so restarts are a no-op rather
  than repeatedly rewriting a 27 MB archive
- the archive is staged and `os.replace`d into place, so an interrupted run
  cannot leave a truncated jar behind

## Reproduction

Before, on `cbioportal/cbioportal:7.0.2`:

```
$ docker run --rm -v "$PWD/entrypoint.sh:/cbioportal/entrypoint.sh:ro" \
    -v "$PWD/config/application.properties:/cbioportal-webapp/application.properties:ro" \
    --entrypoint /cbioportal/entrypoint.sh cbioportal/cbioportal:7.0.2 echo STARTED
/cbioportal/entrypoint.sh: line 5: jar: command not found
exit=127
```

After, the same run reaches `exec` and the jar is valid:

```
=== STARTED (exec works) ===
No errors detected in compressed data of /core/core-IMPORTER.jar.
```

## Verification

Full stack on v7.0.2 (`config/init.sh`, `data/init.sh`, `docker compose up -d`):

- `cbioportal-container` starts clean, no `jar: command not found`
- `GET /api/health` → `{"status":"UP"}`, `GET /` → HTTP 200
- the jar's `application.properties` is byte-identical to the mounted
  `config/application.properties`, and there is exactly one such entry
- the importer reaches ClickHouse with the injected config — `importCaseListData.pl`
  logs `Recaching... Finished recaching...` and then fails only on the study not
  being loaded, where an unconfigured datasource previously failed with
  `Datasource cannot be configured because required properties are missing values`
- editing `config/application.properties` and restarting propagates the change into
  the jar, still with a single entry and `unzip -t` clean