### PR TITLE
Fix entrypoint.sh: replace jar with python3 zipfile

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,23 @@
 set -eo pipefail
 
 ## Inject application.properties into the importer JAR so it overrides the bundled one
-cd /tmp && cp /cbioportal-webapp/application.properties . && jar uf /core/core-IMPORTER.jar application.properties
+## Note: the official cbioportal image ships a JRE (no `jar`/`zip` binary), so we use
+## python3's zipfile module instead of `jar uf`.
+cd /tmp && cp /cbioportal-webapp/application.properties . && python3 - <<'PYEOF'
+import zipfile, shutil
+
+jar_path = "/core/core-IMPORTER.jar"
+new_file = "application.properties"
+tmp_path = jar_path + ".tmp"
+
+with zipfile.ZipFile(jar_path, "r") as zin:
+    with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            if item.filename != new_file:
+                zout.writestr(item, zin.read(item.filename))
+        zout.write(new_file, new_file)
+
+shutil.move(tmp_path, jar_path)
+PYEOF
 
 exec "$@"


### PR DESCRIPTION
Fix: https://github.com/cBioPortal/cbioportal/issues/12293
Official cbioportal/cbioportal images (7.0.1, 7.0.2) ship a JRE-only Java runtime (no jar/zip binary), so `jar uf` fails with "jar: command not found" and the container never starts. The RC image used during rfc100 development (jamesko0/cbioportal:rfc100-rc) was JDK-based, which is why this went unnoticed.

python3 is present in the release image, so use its zipfile module to update application.properties inside core-IMPORTER.jar instead.