### PR TITLE
update clickhouse version to 26.4

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Docker images
-DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:7.0.2
+DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:7.0.5
 DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.4
 DOCKER_IMAGE_CLICKHOUSE=clickhouse/clickhouse-server:24.10
 

--- a/.env
+++ b/.env
@@ -1,32 +1,64 @@
+# TO PREVENT SIDE EFFECTS WITH EXTERNAL PROGRAMS, ALL ENVIRONMENT VARIABLES WE INTRODUCE
+# AS PART OF THE DOCKER CONTAINER ENVIRONMENTS WILL HAVE PREFIX "CP_"
+
 # Docker images
-DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:7.0.5
-DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.4
-DOCKER_IMAGE_CLICKHOUSE=clickhouse/clickhouse-server:24.10
+CP_DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:7.0.5
+CP_DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.4
+CP_DOCKER_IMAGE_CLICKHOUSE=clickhouse/clickhouse-server:26.4
+
+# cBioPortal
+CP_CBIOPORTAL_SERVER_PORT=8080
+CP_SHOW_DEBUG_INFO=true
+CP_APPLICATION_PROPERTIES_PATH=./config/application.properties
+
+# Session service
+CP_SESSION_SERVICE_SERVER_PORT=5001
+CP_SESSION_SERVICE_JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://cbioportal-session-database:27017/session-service
+CP_MONGO_INITDB_DATABASE=session_service
 
 # ClickHouse
-CLICKHOUSE_DB=cbioportal
-CLICKHOUSE_USER=cbio_user
-CLICKHOUSE_PASSWORD=somepassword
-CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
-CLICKHOUSE_HOST=cbioportal-database
-# For ClickHouse Cloud -- the http port usually live at 8443, and the native port at 9440
-CLICKHOUSE_HTTP_PORT=8123
-CLICKHOUSE_NATIVE_PORT=9000
-CLICKHOUSE_URL=jdbc:ch://cbioportal-database:8123/cbioportal
+# Note: the clickhouse database and users are created and configured when the clickhouse service is first initialized.
+#       In order to alter user names, passwords, or the name of the clickhouse database after that point, you will
+#       need to either prune volumes from your docker environment and start with a fresh empty service, or will need
+#       to manually do what is needed to relocate database tables and create / grant new users within clickhouse, etc
+CP_CLICKHOUSE_HOST=cbioportal-database
+CP_CLICKHOUSE_DB=cbioportal
+CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP=cbio_user
+CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_WEB_APP=somepassword
+CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE=cbio_user
+CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE=somepassword
+CP_CLICKHOUSE_USER_FOR_DB_ADMIN=cbio_user
+CP_CLICKHOUSE_PASSWORD_FOR_DB_ADMIN=somepassword
+CP_CLICKHOUSE_USE_SECURE_TRANSPORT=no
+# Note: see below if changing CP_CLICKHOUSE_USE_SECURE_TRANSPORT, which applies to all access (web_app, db_update, db_admin)
+
+# A Clickhouse URL must be set according to user-configured settings above and port settings below
+# Secure ports use TLS encrypted transport (often desired with remote connections such as to clickhouse.cloud)
+CP_CLICKHOUSE_HTTP_INSECURE_PORT=8123
+CP_CLICKHOUSE_HTTP_SECURE_PORT=8443
+CP_CLICKHOUSE_NATIVE_INSECURE_PORT=9000
+CP_CLICKHOUSE_NATIVE_SECURE_PORT=9440
+# The Clickhouse URL must look like this when using insecure transport connections:
+#    jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}/${CP_CLICKHOUSE_DB}
+# The Clickhouse URL must look like this when using secure transport connections:
+#    jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_SECURE_PORT}/${CP_CLICKHOUSE_DB}
+CP_CLICKHOUSE_URL=jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}/${CP_CLICKHOUSE_DB}
+
 # For very large databases, sometimes running multiple OPTIMIZE TABLE .. FINAL
 # statements in sequence during the derived table construction can cause OOM errors.
 # If that happens, try setting this to a larger timeout so we sleep between
 # each statement and give the memory allocator time to free up some memory/
 # By default this sleeping behavior is turned off.
-CLICKHOUSE_OPTIMIZE_BACKOFF_SECS=0
-CLICKHOUSE_SETTINGS_PATH=./data/clickhouse_user_settings.xml
+CP_CLICKHOUSE_OPTIMIZE_BACKOFF_SECS=0
+CP_CLICKHOUSE_SETTINGS_PATH=./data/clickhouse_user_settings.xml
+CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_WEB_APP_PATH=/data/clickhouse_client_web_app_config.yaml
+CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_UPDATE_PATH=/data/clickhouse_client_db_update_config.yaml
+CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_ADMIN_PATH=/data/clickhouse_client_db_admin_config.yaml
+CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_WEB_APP_PATH=/data/clickhouse_client_external_web_app_config.yaml
+CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH=/data/clickhouse_client_external_db_update_config.yaml
+CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_ADMIN_PATH=/data/clickhouse_client_external_db_admin_config.yaml
 
-# cBioPortal
-CBIOPORTAL_SERVER_PORT=8080
-SHOW_DEBUG_INFO=true
-APPLICATION_PROPERTIES_PATH=./config/application.properties
-
-# Session service
-SESSION_SERVICE_SERVER_PORT=5001
-SESSION_SERVICE_JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://cbioportal-session-database:27017/session-service
-MONGO_INITDB_DATABASE=session_service
+# Clickhouse server container initialization
+CLICKHOUSE_USER=${CP_CLICKHOUSE_USER_FOR_DB_ADMIN}
+CLICKHOUSE_PASSWORD=${CP_CLICKHOUSE_PASSWORD_FOR_DB_ADMIN}
+CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/.env
+++ b/.env
@@ -1,32 +1,64 @@
+# TO PREVENT SIDE EFFECTS WITH EXTERNAL PROGRAMS, ALL ENVIRONMENT VARIABLES WE INTRODUCE
+# AS PART OF THE DOCKER CONTAINER ENVIRONMENTS WILL HAVE PREFIX "CP_"
+
 # Docker images
-DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:7.0.5
-DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.4
-DOCKER_IMAGE_CLICKHOUSE=clickhouse/clickhouse-server:24.10
+CP_DOCKER_IMAGE_CBIOPORTAL=cbioportal/cbioportal:7.0.5
+CP_DOCKER_IMAGE_SESSION_SERVICE=cbioportal/session-service:0.6.4
+CP_DOCKER_IMAGE_CLICKHOUSE=clickhouse/clickhouse-server:26.4
+
+# cBioPortal
+CP_CBIOPORTAL_SERVER_PORT=8080
+CP_SHOW_DEBUG_INFO=true
+CP_APPLICATION_PROPERTIES_PATH=./config/application.properties
+
+# Session service
+CP_SESSION_SERVICE_SERVER_PORT=5001
+CP_SESSION_SERVICE_JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://cbioportal-session-database:27017/session-service
+CP_MONGO_INITDB_DATABASE=session_service
 
 # ClickHouse
-CLICKHOUSE_DB=cbioportal
-CLICKHOUSE_USER=cbio_user
-CLICKHOUSE_PASSWORD=somepassword
-CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
-CLICKHOUSE_HOST=cbioportal-database
-# For ClickHouse Cloud -- the http port usually live at 8443, and the native port at 9440
-CLICKHOUSE_HTTP_PORT=8123
-CLICKHOUSE_NATIVE_PORT=9000
-CLICKHOUSE_URL=jdbc:ch://cbioportal-database:8123/cbioportal
+# Note: the clickhouse database and users are created and configured when the clickhouse service is first initialized.
+#       In order to alter user names, passwords, or the name of the clickhouse database after that point, you will
+#       need to either prune volumes from your docker environment and start with a fresh empty service, or will need
+#       to manually do what is needed to relocate database tables and create / grant new users within clickhouse, etc
+CP_CLICKHOUSE_HOST=cbioportal-database
+CP_CLICKHOUSE_DB=cbioportal
+CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP=cbio_user
+CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_WEB_APP=somepassword
+CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE=cbio_user
+CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE=somepassword
+CP_CLICKHOUSE_USER_FOR_DB_ADMIN=cbio_user
+CP_CLICKHOUSE_PASSWORD_FOR_DB_ADMIN=somepassword
+CP_CLICKHOUSE_USE_SECURE_TRANSPORT=no
+# Note: see below if changing CP_CLICKHOUSE_USE_SECURE_TRANSPORT, which applies to all access (web_app, db_update, db_admin)
+
+# A Clickhouse URL must be set according to user-configured settings above and port settings below
+# Secure ports use TLS encrypted transport (often desired with remote connections such as to clickhouse.cloud)
+CP_CLICKHOUSE_HTTP_INSECURE_PORT=8123
+CP_CLICKHOUSE_HTTP_SECURE_PORT=8443
+CP_CLICKHOUSE_NATIVE_INSECURE_PORT=9000
+CP_CLICKHOUSE_NATIVE_SECURE_PORT=9440
+# The Clickhouse URL must look like this when using insecure transport connections:
+#    jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}/${CP_CLICKHOUSE_DB}
+# The Clickhouse URL must look like this when using secure transport connections:
+#    jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_SECURE_PORT}/${CP_CLICKHOUSE_DB}
+CP_CLICKHOUSE_URL=jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}/${CP_CLICKHOUSE_DB}
+
 # For very large databases, sometimes running multiple OPTIMIZE TABLE .. FINAL
 # statements in sequence during the derived table construction can cause OOM errors.
 # If that happens, try setting this to a larger timeout so we sleep between
 # each statement and give the memory allocator time to free up some memory/
 # By default this sleeping behavior is turned off.
-CLICKHOUSE_OPTIMIZE_BACKOFF_SECS=0
-CLICKHOUSE_SETTINGS_PATH=./data/clickhouse_user_settings.xml
+CP_CLICKHOUSE_OPTIMIZE_BACKOFF_SECS=0
+CP_CLICKHOUSE_USER_SETTINGS_PATH=./data/clickhouse_user_settings.xml
+CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_WEB_APP_PATH=/data/clickhouse_client_web_app_config.yaml
+CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_UPDATE_PATH=/data/clickhouse_client_db_update_config.yaml
+CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_ADMIN_PATH=/data/clickhouse_client_db_admin_config.yaml
+CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_WEB_APP_PATH=/data/clickhouse_client_external_web_app_config.yaml
+CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH=/data/clickhouse_client_external_db_update_config.yaml
+CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_ADMIN_PATH=/data/clickhouse_client_external_db_admin_config.yaml
 
-# cBioPortal
-CBIOPORTAL_SERVER_PORT=8080
-SHOW_DEBUG_INFO=true
-APPLICATION_PROPERTIES_PATH=./config/application.properties
-
-# Session service
-SESSION_SERVICE_SERVER_PORT=5001
-SESSION_SERVICE_JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://cbioportal-session-database:27017/session-service
-MONGO_INITDB_DATABASE=session_service
+# Clickhouse server container initialization
+CLICKHOUSE_USER=${CP_CLICKHOUSE_USER_FOR_DB_ADMIN}
+CLICKHOUSE_PASSWORD=${CP_CLICKHOUSE_PASSWORD_FOR_DB_ADMIN}
+CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/addon/clickhouse/docker-compose.remote.clickhouse.yml
+++ b/addon/clickhouse/docker-compose.remote.clickhouse.yml
@@ -7,7 +7,7 @@
 #
 # Connection settings are read from the shell environment (e.g. a CI context such as
 # `clickhouse-public-staging-ro-user`) and override the local defaults baked into .env.
-# Required env vars: CLICKHOUSE_URL, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD.
+# Required env vars: CP_CLICKHOUSE_URL, CP_CLICKHOUSE_USER, CP_CLICKHOUSE_PASSWORD.
 #
 # This restores the pre-v7 `docker-compose.remote.clickhouse.yml` (deleted in the
 # "import to ClickHouse" refactor), adapted to the v7 base compose where ClickHouse
@@ -17,9 +17,9 @@ services:
     # `environment` takes precedence over `env_file` (.env), so these point the running
     # container at the remote ClickHouse instead of jdbc:ch://cbioportal-database:8123.
     environment:
-      CLICKHOUSE_URL: ${CLICKHOUSE_URL:?CLICKHOUSE_URL is required}
-      CLICKHOUSE_USER: ${CLICKHOUSE_USER:?CLICKHOUSE_USER is required}
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD is required}
+      CLICKHOUSE_URL: ${CP_CLICKHOUSE_URL:?CP_CLICKHOUSE_URL is required}
+      CLICKHOUSE_USER: ${CP_CLICKHOUSE_USER:?CP_CLICKHOUSE_USER is required}
+      CLICKHOUSE_PASSWORD: ${CP_CLICKHOUSE_PASSWORD:?CP_CLICKHOUSE_PASSWORD is required}
     # Don't wait on (or require) the local DB healthcheck — we're talking to a remote DB.
     # `!override` replaces the base mapping rather than merging into it.
     depends_on: !override

--- a/config/init.sh
+++ b/config/init.sh
@@ -1,18 +1,39 @@
 #!/usr/bin/env bash
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | tail -n 1 | cut -d '=' -f 2-)
+function output_setting_from_main_env_file() {
+    setting_name="$1"
+    echo "$(egrep "^"${setting_name} ../.env | tail -n 1 | cut -d '=' -f 2-)"
+}
+
+# get needed settings for configuring spring.datasource.clickhouse.url in application.properties from the main docker compose .env file
+CP_DOCKER_IMAGE_CBIOPORTAL="$(output_setting_from_main_env_file CP_DOCKER_IMAGE_CBIOPORTAL)"
+CP_CLICKHOUSE_HOST="$(output_setting_from_main_env_file CP_CLICKHOUSE_HOST)"
+CP_CLICKHOUSE_HTTP_INSECURE_PORT="$(output_setting_from_main_env_file CP_CLICKHOUSE_HTTP_INSECURE_PORT)"
+CP_CLICKHOUSE_HTTP_SECURE_PORT="$(output_setting_from_main_env_file CP_CLICKHOUSE_HTTP_SECURE_PORT)"
+CP_CLICKHOUSE_DB="$(output_setting_from_main_env_file CP_CLICKHOUSE_DB)"
+CP_CLICKHOUSE_USE_SECURE_TRANSPORT="$(output_setting_from_main_env_file CP_CLICKHOUSE_USE_SECURE_TRANSPORT)"
+if [ "$CP_CLICKHOUSE_USE_SECURE_TRANSPORT" == "no" ] ; then
+    CP_CLICKHOUSE_URL="jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}/${CP_CLICKHOUSE_DB}"
+else
+    CP_CLICKHOUSE_URL="jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_SECURE_PORT}/${CP_CLICKHOUSE_DB}"
+fi
 
 # This is a hack. Docker run doesn't escape '&' but docker compose does.
 sed 's/&/\\&/g' ../.env > ../.env.temp
 
-docker run --rm -i --env-file ../.env.temp $VERSION bin/sh -c 'cat /cbioportal-webapp/application.properties |
-    sed "s|spring.datasource.password=.*|spring.datasource.password=${CLICKHOUSE_PASSWORD}|" | \
-    sed "s|spring.datasource.username=.*|spring.datasource.username=${CLICKHOUSE_USER}|" | \
-    sed "s|spring.datasource.url=.*|spring.datasource.url=${CLICKHOUSE_URL}|" | \
-    sed "s|.*spring.datasource.clickhouse.username=.*|spring.datasource.clickhouse.username=${CLICKHOUSE_USER}|" | \
-    sed "s|.*spring.datasource.clickhouse.password=.*|spring.datasource.clickhouse.password=${CLICKHOUSE_PASSWORD}|" | \
-    sed "s|.*spring.datasource.clickhouse.url=.*|spring.datasource.clickhouse.url=${CLICKHOUSE_URL}|"' \
+# add needed environment to .env.temp
+echo "CP_CLICKHOUSE_URL_FINAL=${CP_CLICKHOUSE_URL}" >> ../.env.temp
+
+# update docker image copy of application.properties
+docker run --rm -i --env-file ../.env.temp $CP_DOCKER_IMAGE_CBIOPORTAL bin/sh -c 'cat /cbioportal-webapp/application.properties |
+    sed "s|spring.datasource.password=.*|spring.datasource.password=${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|spring.datasource.username=.*|spring.datasource.username=${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|spring.datasource.url=.*|spring.datasource.url=${CP_CLICKHOUSE_URL_FINAL}|" | \
+    sed "s|.*spring.datasource.clickhouse.username=.*|spring.datasource.clickhouse.username=${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|.*spring.datasource.clickhouse.password=.*|spring.datasource.clickhouse.password=${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|.*spring.datasource.clickhouse.url=.*|spring.datasource.clickhouse.url=${CP_CLICKHOUSE_URL_FINAL}|"' \
 > application.properties
 
 # Cleanup for the hack above

--- a/config/init.sh
+++ b/config/init.sh
@@ -1,18 +1,39 @@
 #!/usr/bin/env bash
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL ../.env | tail -n 1 | cut -d '=' -f 2-)
+function output_setting_from_main_env_file() {
+    setting_name="$1"
+    echo "$(egrep "^"${setting_name} ../.env | tail -n 1 | cut -d '=' -f 2-)"
+}
+
+# get needed settings for configuring spring.datasource.clickhouse.url in application.properties from the main docker compose .env file
+CP_DOCKER_IMAGE_CBIOPORTAL="$(output_setting_from_main_env_file CP_DOCKER_IMAGE_CBIOPORTAL)"
+CP_CLICKHOUSE_HOST="$(output_setting_from_main_env_file CP_CLICKHOUSE_HOST)"
+CP_CLICKHOUSE_HTTP_INSECURE_PORT="$(output_setting_from_main_env_file CP_CLICKHOUSE_HTTP_INSECURE_PORT)"
+CP_CLICKHOUSE_HTTP_SECURE_PORT="$(output_setting_from_main_env_file CP_CLICKHOUSE_HTTP_SECURE_PORT)"
+CP_CLICKHOUSE_DB="$(output_setting_from_main_env_file CP_CLICKHOUSE_DB)"
+CP_CLICKHOUSE_USE_SECURE_TRANSPORT="$(output_setting_from_main_env_file CP_CLICKHOUSE_USE_SECURE_TRANSPORT)"
+if [ "$CP_CLICKHOUSE_USE_SECURE_TRANSPORT" == "no" ] ; then
+    CP_CLICKHOUSE_URL="jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}/${CP_CLICKHOUSE_DB}?compress=0"
+else
+    CP_CLICKHOUSE_URL="jdbc:ch://${CP_CLICKHOUSE_HOST}:${CP_CLICKHOUSE_HTTP_SECURE_PORT}/${CP_CLICKHOUSE_DB}?compress=0"
+fi
 
 # This is a hack. Docker run doesn't escape '&' but docker compose does.
 sed 's/&/\\&/g' ../.env > ../.env.temp
 
-docker run --rm -i --env-file ../.env.temp $VERSION bin/sh -c 'cat /cbioportal-webapp/application.properties |
-    sed "s|spring.datasource.password=.*|spring.datasource.password=${CLICKHOUSE_PASSWORD}|" | \
-    sed "s|spring.datasource.username=.*|spring.datasource.username=${CLICKHOUSE_USER}|" | \
-    sed "s|spring.datasource.url=.*|spring.datasource.url=${CLICKHOUSE_URL}|" | \
-    sed "s|.*spring.datasource.clickhouse.username=.*|spring.datasource.clickhouse.username=${CLICKHOUSE_USER}|" | \
-    sed "s|.*spring.datasource.clickhouse.password=.*|spring.datasource.clickhouse.password=${CLICKHOUSE_PASSWORD}|" | \
-    sed "s|.*spring.datasource.clickhouse.url=.*|spring.datasource.clickhouse.url=${CLICKHOUSE_URL}|"' \
+# add needed environment to .env.temp
+echo "CP_CLICKHOUSE_URL_FINAL=${CP_CLICKHOUSE_URL}" >> ../.env.temp
+
+# update docker image copy of application.properties
+docker run --rm -i --env-file ../.env.temp $CP_DOCKER_IMAGE_CBIOPORTAL bin/sh -c 'cat /cbioportal-webapp/application.properties |
+    sed "s|spring.datasource.password=.*|spring.datasource.password=${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|spring.datasource.username=.*|spring.datasource.username=${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|spring.datasource.url=.*|spring.datasource.url=${CP_CLICKHOUSE_URL_FINAL}|" | \
+    sed "s|.*spring.datasource.clickhouse.username=.*|spring.datasource.clickhouse.username=${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|.*spring.datasource.clickhouse.password=.*|spring.datasource.clickhouse.password=${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}|" | \
+    sed "s|.*spring.datasource.clickhouse.url=.*|spring.datasource.clickhouse.url=${CP_CLICKHOUSE_URL_FINAL}|"' \
 > application.properties
 
 # Cleanup for the hack above

--- a/data/clickhouse_user_settings.xml
+++ b/data/clickhouse_user_settings.xml
@@ -10,5 +10,13 @@
         <cbio_user>
             <profile>client_user_profile</profile>
         </cbio_user>
+<!-- TODO : if multiple user names are enabled through .env, multiple users should be programmatically constructed here in the init.sh script
+        <cbio_updater>
+            <profile>client_user_profile</profile>
+        </cbio_updater>
+        <default>
+            <profile>client_user_profile</profile>
+        </default>
+-->
     </users>
 </clickhouse>

--- a/data/create_cbio_users_and_grant_privileges.sh
+++ b/data/create_cbio_users_and_grant_privileges.sh
@@ -1,0 +1,114 @@
+#/usr/bash
+
+set -eo pipefail
+
+function compare_version() {
+    local ver="$1"
+    local reference_ver="$2"
+    local compare_type="$3"
+
+    local ver_minor_with_tail="${ver#*.}"
+    local ver_major_len=$((${#ver}-${#ver_minor_with_tail}-1))
+    local ver_major="${ver:0:ver_major_len}"
+    local ver_tail="${ver_minor_with_tail#*.}"
+    local ver_minor="${ver_minor_with_tail%%.*}"
+    local reference_ver_minor_with_tail="${reference_ver#*.}"
+    local reference_ver_major_len=$((${#reference_ver}-${#reference_ver_minor_with_tail}-1))
+    local reference_ver_major="${reference_ver:0:reference_ver_major_len}"
+    local reference_ver_tail="${reference_ver_minor_with_tail#*.}"
+    local reference_ver_minor="${reference_ver_minor_with_tail%%.*}"
+    case "$compare_type" in
+        "lt")
+            if [ "$ver_major" -lt "$reference_ver_major" ] ; then
+                return 0
+            fi
+            if [ "$ver_major" -eq "$reference_ver_major" ] && [ "$ver_minor" -lt "$reference_ver_minor" ] ; then
+                return 0
+            fi
+            ;;
+        "eq")
+            if [ "$ver_major" -eq "$reference_ver_major" ] && [ "$ver_minor" -eq "$reference_ver_minor" ] ; then
+                return 0
+            fi
+            ;;
+        "le")
+            if [ "$ver_major" -lt "$reference_ver_major" ] ; then
+                return 0
+            fi
+            if [ "$ver_major" -eq "$reference_ver_major" ] && [ "$ver_minor" -le "$reference_ver_minor" ] ; then
+                return 0
+            fi
+            ;;
+        *)
+            echo "Warning : called compare_version() bash function on unknown compare_type argument: '$compare_type'" >&2
+            ;;
+    esac
+    return 1 # catchall for false/fail return
+}
+
+function version_is_older() {
+    local ver="$1"
+    local reference_ver="$2"
+    if compare_version "$ver" "$reference_ver" "lt" ; then
+        return 0
+    fi
+    return 1
+}
+
+function version_is_equal() {
+    local ver="$1"
+    local reference_ver="$2"
+    if compare_version "$ver" "$reference_ver" "eq" ; then
+        return 0
+    fi
+    return 1
+}
+
+function version_is_older_or_equal() {
+    local ver="$1"
+    local reference_ver="$2"
+    if compare_version "$ver" "$reference_ver" "le" ; then
+        return 0
+    fi
+    return 1
+}
+
+function execute_clickhouse_statement() {
+    local statement_string="$1"
+    clickhouse client --config-file .${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_ADMIN_PATH} --query "$statement_string"
+}
+
+# account may alredy exist if user has configured all three roles (db_admin / db_updater / web_app) to use the same (root privileged) account 
+sql_statement="SELECT count() FROM system.users WHERE name = '${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}'"
+account_for_web_app_user_already_exists="$(execute_clickhouse_statement "${sql_statement}")"
+if [ "$account_for_web_app_user_already_exists" == "0" ] ; then
+    execute_clickhouse_statement "CREATE USER ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP} IDENTIFIED WITH sha256_password BY '${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_WEB_APP}'"
+    execute_clickhouse_statement "GRANT SELECT ON ${CP_CLICKHOUSE_DB}.* TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}"
+    execute_clickhouse_statement "GRANT INSERT, ALTER, TRUNCATE ON ${CP_CLICKHOUSE_DB}.data_access_token TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}"
+fi
+sql_statement="SELECT count() FROM system.users WHERE name = '${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}'"
+account_for_db_update_user_already_exists="$(execute_clickhouse_statement "${sql_statement}")"
+if [ "$account_for_db_update_user_already_exists" == "0" ] ; then
+    execute_clickhouse_statement "CREATE USER ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE} IDENTIFIED WITH sha256_password BY '${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}'"
+    execute_clickhouse_statement "GRANT SHOW TABLES, SHOW COLUMNS, SELECT, INSERT, ALTER, CREATE TABLE, CREATE VIEW, DROP TABLE, DROP VIEW, TRUNCATE, OPTIMIZE ON ${CP_CLICKHOUSE_DB}.* TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}" 
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.tables TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.parts TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.mutations TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.one TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    detected_clickhouse_version="$(execute_clickhouse_statement 'SELECT version()')"
+    if version_is_older "$detected_clickhouse_version" "24.10.x" ; then
+        echo "Warning : initialization of clickhouse versions before 24.10 is unsupported and may result in a system which fails to properly import studies" >&2
+    fi
+    if version_is_older_or_equal "$detected_clickhouse_version" "25.6.x" ; then
+        execute_clickhouse_statement "GRANT CLUSTER ON *.* TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    else
+        if version_is_older_or_equal "$detected_clickhouse_version" "26.4.x" ; then
+            execute_clickhouse_statement "GRANT READ ON REMOTE TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+        else
+            echo "Warning : initialization of clickhouse versions after 26.4 has not yet been evaluated. Problems are not expected, but be advised that version '$ver' has not yet been tested." >&2
+            execute_clickhouse_statement "GRANT READ ON REMOTE TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+        fi
+    fi
+fi
+
+

--- a/data/create_cbio_users_and_grant_privileges.sh
+++ b/data/create_cbio_users_and_grant_privileges.sh
@@ -1,0 +1,112 @@
+#/usr/bash
+
+set -eo pipefail
+
+function compare_version() {
+    local ver="$1"
+    local reference_ver="$2"
+    local compare_type="$3"
+
+    local ver_minor_with_tail="${ver#*.}"
+    local ver_major_len=$((${#ver}-${#ver_minor_with_tail}-1))
+    local ver_major="${ver:0:ver_major_len}"
+    local ver_tail="${ver_minor_with_tail#*.}"
+    local ver_minor="${ver_minor_with_tail%%.*}"
+    local reference_ver_minor_with_tail="${reference_ver#*.}"
+    local reference_ver_major_len=$((${#reference_ver}-${#reference_ver_minor_with_tail}-1))
+    local reference_ver_major="${reference_ver:0:reference_ver_major_len}"
+    local reference_ver_tail="${reference_ver_minor_with_tail#*.}"
+    local reference_ver_minor="${reference_ver_minor_with_tail%%.*}"
+    case "$compare_type" in
+        "lt")
+            if [ "$ver_major" -lt "$reference_ver_major" ] ; then
+                return 0
+            fi
+            if [ "$ver_major" -eq "$reference_ver_major" ] && [ "$ver_minor" -lt "$reference_ver_minor" ] ; then
+                return 0
+            fi
+            ;;
+        "eq")
+            if [ "$ver_major" -eq "$reference_ver_major" ] && [ "$ver_minor" -eq "$reference_ver_minor" ] ; then
+                return 0
+            fi
+            ;;
+        "le")
+            if [ "$ver_major" -lt "$reference_ver_major" ] ; then
+                return 0
+            fi
+            if [ "$ver_major" -eq "$reference_ver_major" ] && [ "$ver_minor" -le "$reference_ver_minor" ] ; then
+                return 0
+            fi
+            ;;
+        *)
+            echo "Warning : called compare_version() bash function on unknown compare_type argument: '$compare_type'" >&2
+            ;;
+    esac
+    return 1 # catchall for false/fail return
+}
+
+function version_is_older() {
+    local ver="$1"
+    local reference_ver="$2"
+    if compare_version "$ver" "$reference_ver" "lt" ; then
+        return 0
+    fi
+    return 1
+}
+
+function version_is_equal() {
+    local ver="$1"
+    local reference_ver="$2"
+    if compare_version "$ver" "$reference_ver" "eq" ; then
+        return 0
+    fi
+    return 1
+}
+
+function version_is_older_or_equal() {
+    local ver="$1"
+    local reference_ver="$2"
+    if compare_version "$ver" "$reference_ver" "le" ; then
+        return 0
+    fi
+    return 1
+}
+
+function execute_clickhouse_statement() {
+    local statement_string="$1"
+    clickhouse client --config-file .${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_ADMIN_PATH} --query "$statement_string"
+}
+
+# account may alredy exist if user has configured all three roles (db_admin / db_updater / web_app) to use the same (root privileged) account 
+sql_statement="SELECT count() FROM system.users WHERE name = '${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}'"
+account_for_db_update_user_already_exists="$(execute_clickhouse_statement "${sql_statement}")"
+if [ "$account_for_db_update_user_already_exists" == "0" ] ; then
+    execute_clickhouse_statement "CREATE USER ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE} IDENTIFIED WITH sha256_password BY '${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}'"
+    execute_clickhouse_statement "GRANT SHOW TABLES, SHOW COLUMNS, SELECT, INSERT, ALTER, CREATE TABLE, CREATE VIEW, DROP TABLE, DROP VIEW, TRUNCATE, OPTIMIZE ON ${CP_CLICKHOUSE_DB}.* TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}" 
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.tables TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.parts TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.mutations TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    execute_clickhouse_statement "GRANT SHOW COLUMNS, SELECT ON system.one TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    detected_clickhouse_version="$(execute_clickhouse_statement 'SELECT version()')"
+    if version_is_older "$detected_clickhouse_version" "24.10.x" ; then
+        echo "Warning : initialization of clickhouse versions before 24.10 is unsupported and may result in a system which fails to properly import studies" >&2
+    fi
+    if version_is_older_or_equal "$detected_clickhouse_version" "25.6.x" ; then
+        execute_clickhouse_statement "GRANT CLUSTER ON *.* TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+    else
+        if version_is_older_or_equal "$detected_clickhouse_version" "26.4.x" ; then
+            execute_clickhouse_statement "GRANT READ ON REMOTE TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+        else
+            echo "Warning : initialization of clickhouse versions after 26.4 has not yet been evaluated. Problems are not expected, but be advised that version '$ver' has not yet been tested." >&2
+            execute_clickhouse_statement "GRANT READ ON REMOTE TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}"
+        fi
+    fi
+fi
+sql_statement="SELECT count() FROM system.users WHERE name = '${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}'"
+account_for_web_app_user_already_exists="$(execute_clickhouse_statement "${sql_statement}")"
+if [ "$account_for_web_app_user_already_exists" == "0" ] ; then
+    execute_clickhouse_statement "CREATE USER ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP} IDENTIFIED WITH sha256_password BY '${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_WEB_APP}'"
+    execute_clickhouse_statement "GRANT SELECT ON ${CP_CLICKHOUSE_DB}.* TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}"
+    execute_clickhouse_statement "GRANT INSERT, ALTER, TRUNCATE ON ${CP_CLICKHOUSE_DB}.data_access_token TO ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}"
+fi

--- a/data/create_cbioportal_database.sh
+++ b/data/create_cbioportal_database.sh
@@ -1,0 +1,11 @@
+#/usr/bash
+
+set -eo pipefail
+
+function execute_clickhouse_statement() {
+    local statement_string="$1"
+    # --database argument is needed because cbioportal database (referenced in config file) will not yet exist until after this statement is executed.
+    clickhouse client --config-file .${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_ADMIN_PATH} --database system --query "$statement_string"
+}
+
+execute_clickhouse_statement "CREATE DATABASE ${CP_CLICKHOUSE_DB}"

--- a/data/init.sh
+++ b/data/init.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
+
 set -eo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 VERSION=$(grep DOCKER_IMAGE_CBIOPORTAL "${SCRIPT_DIR}/../.env" | tail -n 1 | cut -d '=' -f 2-)
-
 CONTAINER=$(docker create $VERSION)
+
 trap 'docker rm $CONTAINER' EXIT
 
 docker cp $CONTAINER:/cbioportal/db-scripts/clickhouse/init/schema.sql "${SCRIPT_DIR}/schema.sql"

--- a/data/load_derived_tables.sh
+++ b/data/load_derived_tables.sh
@@ -2,11 +2,9 @@
 set -eo pipefail
 
 echo "Creating derived tables..."
-clickhouse-client \
-    --user "${CLICKHOUSE_USER}" \
-    --password "${CLICKHOUSE_PASSWORD}" \
-    --database "${CLICKHOUSE_DB}" \
+clickhouse client \
+    --config-file ".${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_UPDATE_PATH}" \
     --multiquery \
-    --param_optimize_backoff_secs="${CLICKHOUSE_OPTIMIZE_BACKOFF_SECS:-0}" \
+    --param_optimize_backoff_secs="${CP_CLICKHOUSE_OPTIMIZE_BACKOFF_SECS:-0}" \
     < /data/clickhouse.sql
 echo "Successfully created derived tables."

--- a/data/load_schema.sh
+++ b/data/load_schema.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
-# This script is executed during ClickHouse container initialization (via docker-entrypoint-initdb.d).
+# This script is executed during Clickhouse container initialization (via docker-entrypoint-initdb.d).
 # It loads the base schema from the SQL file.
 set -eo pipefail
 
 echo "Loading schema..."
-clickhouse-client \
-    --user "${CLICKHOUSE_USER}" \
-    --password "${CLICKHOUSE_PASSWORD}" \
-    --database "${CLICKHOUSE_DB}" \
+clickhouse client \
+    --config-file ".${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_UPDATE_PATH}" \
     --multiquery \
     < /data/schema.sql
 echo "Successfully loaded schema."

--- a/data/load_seed.sh
+++ b/data/load_seed.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-# This script is executed during ClickHouse container initialization (via docker-entrypoint-initdb.d).
+# This script is executed during Clickhouse container initialization (via docker-entrypoint-initdb.d).
 # It loads the seed database (reference data: genes, cancer types, etc.) from the compressed SQL dump.
 set -eo pipefail
 
 echo "Loading seed data..."
-gunzip -c /data/seed.sql.gz | clickhouse-client \
-  --user "${CLICKHOUSE_USER}" \
-  --password "${CLICKHOUSE_PASSWORD}" \
-  --database "${CLICKHOUSE_DB}" \
+gunzip -c /data/seed.sql.gz | clickhouse client \
+  --config-file ."${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_UPDATE_PATH}" \
   --multiquery
 echo "Successfully loaded seed data."

--- a/data/write_clickhouse_client_config_files.sh
+++ b/data/write_clickhouse_client_config_files.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# This script is executed during Clickhouse container initialization (via docker-entrypoint-initdb.d).
+# It writes the Clickhouse client configuration files from environment variable settings,
+# enabling access to the clickhouse-database from the host environment.
+
+set -eo pipefail
+
+function write_clickhouse_client_config_file_for_user() {
+    local outfilepath="$1"
+    local user_description="$2"
+    local internal_or_external="$3"
+    local username="$4"
+    local password="$5"
+    echo "Writing Clickhouse client config file for ${user_description}..."
+    echo -n > "${outfilepath}" # truncate file
+    echo "user: ${username}" >> "${outfilepath}"
+    echo "password: ${password}" >> "${outfilepath}"
+    if [ "$internal_or_external" == "external" ] ; then
+        echo "host: ${CP_CLICKHOUSE_HOST}" >> "${outfilepath}"
+    else
+        echo "host: localhost" >> "${outfilepath}"
+    fi
+    echo "database: ${CP_CLICKHOUSE_DB}" >> "${outfilepath}"
+    if [ "${CP_CLICKHOUSE_USE_SECURE_TRANSPORT}" == "yes" ] ; then
+        echo "port: ${CP_CLICKHOUSE_NATIVE_SECURE_PORT}" >> "${outfilepath}"
+        echo "secure: true" >> "${outfilepath}"
+    else
+        echo "port: ${CP_CLICKHOUSE_NATIVE_INSECURE_PORT}" >> "${outfilepath}"
+        echo "secure: false" >> "${outfilepath}"
+    fi
+}
+
+write_clickhouse_client_config_file_for_user \
+        ".${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_ADMIN_PATH}" \
+        "db admin user" \
+        "internal" \
+        "${CP_CLICKHOUSE_USER_FOR_DB_ADMIN}" \
+        "${CP_CLICKHOUSE_PASSWORD_FOR_DB_ADMIN}"
+write_clickhouse_client_config_file_for_user \
+        ".${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_DB_UPDATE_PATH}" \
+        "db update user" \
+        "internal" \
+        "${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}" \
+        "${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}"
+write_clickhouse_client_config_file_for_user \
+        ".${CP_CLICKHOUSE_CLIENT_INTERNAL_CONFIG_FOR_WEB_APP_PATH}" \
+        "web app user" \
+        "internal" \
+        "${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}" \
+        "${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_WEB_APP}"
+write_clickhouse_client_config_file_for_user \
+        "${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_ADMIN_PATH}" \
+        "db admin user" \
+        "external" \
+        "${CP_CLICKHOUSE_USER_FOR_DB_ADMIN}" \
+        "${CP_CLICKHOUSE_PASSWORD_FOR_DB_ADMIN}"
+write_clickhouse_client_config_file_for_user \
+        "${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH}" \
+        "db update user" \
+        "external" \
+        "${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}" \
+        "${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}"
+write_clickhouse_client_config_file_for_user \
+        "${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_WEB_APP_PATH}" \
+        "web app user" \
+        "external" \
+        "${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_WEB_APP}" \
+        "${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_WEB_APP}"

--- a/dev/docker-compose.web.yml
+++ b/dev/docker-compose.web.yml
@@ -15,15 +15,15 @@ services:
       -Xmx4g 
       -jar /cbioportal-webapp/app.jar  
       --authenticate=false 
-      --session.service.url=http://cbioportal-session:5001/api/sessions/my_portal/
+      --session.service.url=http://cbioportal-session:${CP_SESSION_SERVICE_SERVER_PORT}/api/sessions/my_portal/
       --spring.datasource.driver-class-name=com.clickhouse.jdbc.ClickHouseDriver
-      --spring.datasource.url=$${CLICKHOUSE_URL}
-      --spring.datasource.username=$${CLICKHOUSE_USER}
-      --spring.datasource.password=$${CLICKHOUSE_PASSWORD}
-      --spring.datasource.clickhouse.url=$${CLICKHOUSE_URL}
-      --spring.datasource.clickhouse.username=$${CLICKHOUSE_USER}
-      --spring.datasource.clickhouse.password=$${CLICKHOUSE_PASSWORD}
+      --spring.datasource.url=$${CP_CLICKHOUSE_URL}
+      --spring.datasource.username=$${CP_CLICKHOUSE_USER}
+      --spring.datasource.password=$${CP_CLICKHOUSE_PASSWORD}
+      --spring.datasource.clickhouse.url=$${CP_CLICKHOUSE_URL}
+      --spring.datasource.clickhouse.username=$${CP_CLICKHOUSE_USER}
+      --spring.datasource.clickhouse.password=$${CP_CLICKHOUSE_PASSWORD}
       --spring.datasource.clickhouse.driver-class-name=com.clickhouse.jdbc.ClickHouseDriver
-      --clickhouse_mode=$${APP_CLICKHOUSE_MODE:-true}
-      $${APP_CUSTOM_ARGS}
+      --clickhouse_mode=$${CP_APP_CLICKHOUSE_MODE:-true}
+      $${CP_APP_CUSTOM_ARGS}
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,30 @@
 services:
   cbioportal:
     restart: unless-stopped
-    image: ${DOCKER_IMAGE_CBIOPORTAL}
+    image: ${CP_DOCKER_IMAGE_CBIOPORTAL}
     container_name: cbioportal-container
     env_file:
       - .env
     environment:
-      SERVER_PORT: ${CBIOPORTAL_SERVER_PORT}
+      SERVER_PORT: ${CP_CBIOPORTAL_SERVER_PORT}
+      # begin - For backwards compatibility while we make the cbioportal web application "db user aware"
+      CLICKHOUSE_USER: ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}
+      CLICKHOUSE_PASSWORD: ${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}
+      CLICKHOUSE_HOST: ${CP_CLICKHOUSE_HOST}
+      CLICKHOUSE_NATIVE_PORT: ${CP_CLICKHOUSE_NATIVE_INSECURE_PORT}
+      CLICKHOUSE_DB: ${CP_CLICKHOUSE_DB}
+      CLICKHOUSE_URL: ${CP_CLICKHOUSE_URL}
+      CLICKHOUSE_OPTIMIZE_BACKOFF_SECS: ${CP_CLICKHOUSE_OPTIMIZE_BACKOFF_SECS}
+      CBIOPORTAL_SERVER_PORT: ${CP_CBIOPORTAL_SERVER_PORT}
+      SHOW_DEBUG_INFO: ${CP_SHOW_DEBUG_INFO}
+      APPLICATION_PROPERTIES_PATH: ${CP_APPLICATION_PROPERTIES_PATH}
+      # end - For backwards compatibility while we make the cbioportal web application "db user aware"
     ports:
-      - "8080:8080"
+      - "${CP_CBIOPORTAL_SERVER_PORT}:${CP_CBIOPORTAL_SERVER_PORT}"
     entrypoint: [ "/cbioportal/entrypoint.sh" ]
     volumes:
       - ./study:/study/
       - ./entrypoint.sh:/cbioportal/entrypoint.sh
-
       - ${APPLICATION_PROPERTIES_PATH:-./config/application.properties}:/cbioportal-webapp/application.properties:ro
       # We need to mount the derived table script into the cbioportal container
       # The metaImport script looks for it under $PORTAL_HOME
@@ -25,29 +36,37 @@ services:
         condition: service_started
     networks:
      - cbio-net
-    command: /bin/sh -c "java -Xms2g -Xmx4g -cp '/cbioportal-webapp:/cbioportal-webapp/lib/*' org.cbioportal.PortalApplication --spring.config.location=file:/cbioportal-webapp/application.properties --authenticate=false --session.service.url=http://cbioportal-session:5001/api/sessions/my_portal/ --clickhouse_mode=true --spring.profiles.active=clickhouse"
+    command: /bin/sh -c "java -Xms2g -Xmx4g -cp '/cbioportal-webapp:/cbioportal-webapp/lib/*' org.cbioportal.PortalApplication --spring.config.location=file:/cbioportal-webapp/application.properties --authenticate=false --session.service.url=http://cbioportal-session:${CP_SESSION_SERVICE_SERVER_PORT}/api/sessions/my_portal/ --clickhouse_mode=true --spring.profiles.active=clickhouse"
 
   cbioportal-database:
     restart: unless-stopped
-    image: ${DOCKER_IMAGE_CLICKHOUSE}
+    image: ${CP_DOCKER_IMAGE_CLICKHOUSE}
     container_name: cbioportal-database-container
     env_file:
       - .env
     ports:
-      - "8123:8123"
-      - "9000:9000"
+      - ${CP_CLICKHOUSE_HTTP_INSECURE_PORT}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}
+      - ${CP_CLICKHOUSE_HTTP_SECURE_PORT}:${CP_CLICKHOUSE_HTTP_SECURE_PORT}
+      - ${CP_CLICKHOUSE_NATIVE_INSECURE_PORT}:${CP_CLICKHOUSE_NATIVE_INSECURE_PORT}
+      - ${CP_CLICKHOUSE_NATIVE_SECURE_PORT}:${CP_CLICKHOUSE_NATIVE_SECURE_PORT}
     volumes:
       - ./data/schema.sql:/data/schema.sql:ro
-      - ./data/load_schema.sh:/docker-entrypoint-initdb.d/001_load_schema.sh:ro
       - ./data/seed.sql.gz:/data/seed.sql.gz:ro
-      - ./data/load_seed.sh:/docker-entrypoint-initdb.d/002_load_seed.sh:ro
       - ./data/clickhouse.sql:/data/clickhouse.sql:ro
-      - ./data/load_derived_tables.sh:/docker-entrypoint-initdb.d/003_load_derived_tables.sh:ro
+      - .${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_WEB_APP_PATH}:${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_WEB_APP_PATH}:rw
+      - .${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH}:${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH}:rw
+      - .${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_ADMIN_PATH}:${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_ADMIN_PATH}:rw
+      - ./data/write_clickhouse_client_config_files.sh:/docker-entrypoint-initdb.d/001_write_clickhouse_client_config_files.sh:ro
+      - ./data/create_cbioportal_database.sh:/docker-entrypoint-initdb.d/002_create_cbioportal_database.sh:ro
+      - ./data/create_cbio_users_and_grant_privileges.sh:/docker-entrypoint-initdb.d/003_create_users_and_write_privileges.sh:ro
+      - ./data/load_schema.sh:/docker-entrypoint-initdb.d/004_load_schema.sh:ro
+      - ./data/load_seed.sh:/docker-entrypoint-initdb.d/005_load_seed.sh:ro
+      - ./data/load_derived_tables.sh:/docker-entrypoint-initdb.d/006_load_derived_tables.sh:ro
       - cbioportal_clickhouse_data:/var/lib/clickhouse
     networks:
       - cbio-net
     healthcheck:
-      test: ["CMD-SHELL", "clickhouse-client --user=$$CLICKHOUSE_USER --password=$$CLICKHOUSE_PASSWORD --query=\"SELECT COUNT(*) FROM $$CLICKHOUSE_DB.type_of_cancer\" 2>/dev/null | grep -q '^[1-9]'"]
+      test: ["CMD-SHELL", "clickhouse client --config-file=.${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH} --query=\"SELECT COUNT(*) FROM $$CP_CLICKHOUSE_DB.type_of_cancer\" 2>/dev/null | grep -q '^[1-9]'"]
       interval: 10s
       timeout: 3s
       retries: 300
@@ -55,13 +74,13 @@ services:
 
   cbioportal-session:
     restart: unless-stopped
-    image: ${DOCKER_IMAGE_SESSION_SERVICE}
+    image: ${CP_DOCKER_IMAGE_SESSION_SERVICE}
     container_name: cbioportal-session-container
     env_file:
       - .env
     environment:
-      SERVER_PORT: ${SESSION_SERVICE_SERVER_PORT}
-      JAVA_OPTS: ${SESSION_SERVICE_JAVA_OPTS}
+      SERVER_PORT: ${CP_SESSION_SERVICE_SERVER_PORT}
+      JAVA_OPTS: ${CP_SESSION_SERVICE_JAVA_OPTS}
     depends_on:
       - cbioportal-session-database
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,30 @@
 services:
   cbioportal:
     restart: unless-stopped
-    image: ${DOCKER_IMAGE_CBIOPORTAL}
+    image: ${CP_DOCKER_IMAGE_CBIOPORTAL}
     container_name: cbioportal-container
     env_file:
       - .env
     environment:
-      SERVER_PORT: ${CBIOPORTAL_SERVER_PORT}
+      SERVER_PORT: ${CP_CBIOPORTAL_SERVER_PORT}
+      # begin - For backwards compatibility while we make the cbioportal web application "db user aware"
+      CLICKHOUSE_USER: ${CP_CLICKHOUSE_USER_FOR_CBIOPORTAL_DB_UPDATE}
+      CLICKHOUSE_PASSWORD: ${CP_CLICKHOUSE_PASSWORD_FOR_CBIOPORTAL_DB_UPDATE}
+      CLICKHOUSE_HOST: ${CP_CLICKHOUSE_HOST}
+      CLICKHOUSE_NATIVE_PORT: ${CP_CLICKHOUSE_NATIVE_INSECURE_PORT}
+      CLICKHOUSE_DB: ${CP_CLICKHOUSE_DB}
+      CLICKHOUSE_URL: ${CP_CLICKHOUSE_URL}
+      CLICKHOUSE_OPTIMIZE_BACKOFF_SECS: ${CP_CLICKHOUSE_OPTIMIZE_BACKOFF_SECS}
+      CBIOPORTAL_SERVER_PORT: ${CP_CBIOPORTAL_SERVER_PORT}
+      SHOW_DEBUG_INFO: ${CP_SHOW_DEBUG_INFO}
+      APPLICATION_PROPERTIES_PATH: ${CP_APPLICATION_PROPERTIES_PATH}
+      # end - For backwards compatibility while we make the cbioportal web application "db user aware"
     ports:
-      - "8080:8080"
+      - "${CP_CBIOPORTAL_SERVER_PORT}:${CP_CBIOPORTAL_SERVER_PORT}"
     entrypoint: [ "/cbioportal/entrypoint.sh" ]
     volumes:
       - ./study:/study/
       - ./entrypoint.sh:/cbioportal/entrypoint.sh
-
       - ${APPLICATION_PROPERTIES_PATH:-./config/application.properties}:/cbioportal-webapp/application.properties:ro
       # We need to mount the derived table script into the cbioportal container
       # The metaImport script looks for it under $PORTAL_HOME
@@ -25,29 +36,38 @@ services:
         condition: service_started
     networks:
      - cbio-net
-    command: /bin/sh -c "java -Xms2g -Xmx4g -cp '/cbioportal-webapp:/cbioportal-webapp/lib/*' org.cbioportal.PortalApplication --spring.config.location=file:/cbioportal-webapp/application.properties --authenticate=false --session.service.url=http://cbioportal-session:5001/api/sessions/my_portal/ --clickhouse_mode=true --spring.profiles.active=clickhouse"
+    command: /bin/sh -c "java -Xms2g -Xmx4g -cp '/cbioportal-webapp:/cbioportal-webapp/lib/*' org.cbioportal.PortalApplication --spring.config.location=file:/cbioportal-webapp/application.properties --authenticate=false --session.service.url=http://cbioportal-session:${CP_SESSION_SERVICE_SERVER_PORT}/api/sessions/my_portal/ --clickhouse_mode=true --spring.profiles.active=clickhouse"
 
   cbioportal-database:
     restart: unless-stopped
-    image: ${DOCKER_IMAGE_CLICKHOUSE}
+    image: ${CP_DOCKER_IMAGE_CLICKHOUSE}
     container_name: cbioportal-database-container
     env_file:
       - .env
     ports:
-      - "8123:8123"
-      - "9000:9000"
+      - ${CP_CLICKHOUSE_HTTP_INSECURE_PORT}:${CP_CLICKHOUSE_HTTP_INSECURE_PORT}
+      - ${CP_CLICKHOUSE_HTTP_SECURE_PORT}:${CP_CLICKHOUSE_HTTP_SECURE_PORT}
+      - ${CP_CLICKHOUSE_NATIVE_INSECURE_PORT}:${CP_CLICKHOUSE_NATIVE_INSECURE_PORT}
+      - ${CP_CLICKHOUSE_NATIVE_SECURE_PORT}:${CP_CLICKHOUSE_NATIVE_SECURE_PORT}
     volumes:
       - ./data/schema.sql:/data/schema.sql:ro
-      - ./data/load_schema.sh:/docker-entrypoint-initdb.d/001_load_schema.sh:ro
       - ./data/seed.sql.gz:/data/seed.sql.gz:ro
-      - ./data/load_seed.sh:/docker-entrypoint-initdb.d/002_load_seed.sh:ro
       - ./data/clickhouse.sql:/data/clickhouse.sql:ro
-      - ./data/load_derived_tables.sh:/docker-entrypoint-initdb.d/003_load_derived_tables.sh:ro
+      - .${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_WEB_APP_PATH}:${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_WEB_APP_PATH}:rw
+      - .${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH}:${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH}:rw
+      - .${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_ADMIN_PATH}:${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_ADMIN_PATH}:rw
+      - ./data/write_clickhouse_client_config_files.sh:/docker-entrypoint-initdb.d/001_write_clickhouse_client_config_files.sh:ro
+      - ./data/create_cbioportal_database.sh:/docker-entrypoint-initdb.d/002_create_cbioportal_database.sh:ro
+      - ./data/create_cbio_users_and_grant_privileges.sh:/docker-entrypoint-initdb.d/003_create_users_and_write_privileges.sh:ro
+      - ./data/load_schema.sh:/docker-entrypoint-initdb.d/004_load_schema.sh:ro
+      - ./data/load_seed.sh:/docker-entrypoint-initdb.d/005_load_seed.sh:ro
+      - ./data/load_derived_tables.sh:/docker-entrypoint-initdb.d/006_load_derived_tables.sh:ro
       - cbioportal_clickhouse_data:/var/lib/clickhouse
+      - ${CP_CLICKHOUSE_USER_SETTINGS_PATH}:/etc/clickhouse-server/users.d/001_additional_user_settings.xml
     networks:
       - cbio-net
     healthcheck:
-      test: ["CMD-SHELL", "clickhouse-client --user=$$CLICKHOUSE_USER --password=$$CLICKHOUSE_PASSWORD --query=\"SELECT COUNT(*) FROM $$CLICKHOUSE_DB.type_of_cancer\" 2>/dev/null | grep -q '^[1-9]'"]
+      test: ["CMD-SHELL", "clickhouse client --config-file=.${CP_CLICKHOUSE_CLIENT_EXTERNAL_CONFIG_FOR_DB_UPDATE_PATH} --query=\"SELECT COUNT(*) FROM $$CP_CLICKHOUSE_DB.type_of_cancer\" 2>/dev/null | grep -q '^[1-9]'"]
       interval: 10s
       timeout: 3s
       retries: 300
@@ -55,13 +75,13 @@ services:
 
   cbioportal-session:
     restart: unless-stopped
-    image: ${DOCKER_IMAGE_SESSION_SERVICE}
+    image: ${CP_DOCKER_IMAGE_SESSION_SERVICE}
     container_name: cbioportal-session-container
     env_file:
       - .env
     environment:
-      SERVER_PORT: ${SESSION_SERVICE_SERVER_PORT}
-      JAVA_OPTS: ${SESSION_SERVICE_JAVA_OPTS}
+      SERVER_PORT: ${CP_SESSION_SERVICE_SERVER_PORT}
+      JAVA_OPTS: ${CP_SESSION_SERVICE_JAVA_OPTS}
     depends_on:
       - cbioportal-session-database
     networks:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -eo pipefail
 
 ## Inject application.properties into the importer JAR so it overrides the bundled one

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+
 for d in config study data; do
-    cd $d; ./init.sh
+    cd $d
+    ./init.sh
     cd ..
 done
-

--- a/study/init.sh
+++ b/study/init.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
This upgrades the Clickhouse version deployed in docker compose for the cbioportal database to the current production version of Clickhouse we are running in clickhouse.cloud.

This PR needs to be expanded to support users who have a populated database under the old Clickhouse version we were using (24.10). So please do not merge until that advice / support has been added.

Additionally, a bug needs to be resolved where requests to the Clickhouse server are apparently receiving compressed responses to http requests which are unreadable by the current cBioPortal Clickhouse driver. We may need to upgrade the driver, or diagnose the compression clash and specify a limit to what the driver accepts by updating the "Accept:" header in the request. For now, for testing purposes we have worked around this bug by appending argument "?compress=0" to the datasource URL.